### PR TITLE
Semantic alignment of error messages texts (Markus Rentschler, Balluff)

### DIFF
--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -42,9 +42,7 @@ info:
     * [206] HTTP Status 400: Data value out of bounds
       - Remark: An array/string was accessed exceeding its maximum length
 
-<<<<<<< .mine    * [207] HTTP Status 400: deviceName is not unique
-=======    * [207] HTTP Status 400: Duplicated deviceAlias
->>>>>>> .theirs
+    * [207] HTTP Status 400: deviceAlias is not unique
 
     ### Resource access errors
 
@@ -4690,7 +4688,7 @@ components:
               $ref: '#/components/schemas/content'
             format:
               $ref: '#/components/schemas/format'
-      oneOf:s
+      oneOf:
         - type: object
           required:
             - interval

--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -16,37 +16,37 @@ info:
 
     * [103] HTTP Status 404: Operation not supported
 
-    * [104] HTTP Status 400: Action locked by another client
-      - Remark: Fieldbus controller or another gateway protocol has claimed priority
+    * [104] HTTP Status 400: Action locked by another client (e.g. fieldbus
+    controller)
 
-    * [150] HTTP Status 403: Permission denied
-      - Remark: e.g. by  user management
+    * [150] HTTP Status 403: Permission denied (e.g. user management)
 
 
     ### JSON Parsing errors
 
-    * [201] HTTP Status 400: Parsing failed
-      - Remark: Error while parsing the incoming JSON value
+    * [201] HTTP Status 400: Parsing failed (error while parsing the incoming
+    JSON value)
 
-    * [202] HTTP Status 400: Data value invalid
-      - Remark: given for the value, e.g. malformed IP address
+    * [202] HTTP Status 400: Invalid data (given for the value, e.g. malformed
+    IP address)
 
-    * [203] HTTP Status 400: Data type invalid
-      - Remark: e.g. string instead of number
+    * [203] HTTP Status 400: Invalid JSON data type (e.g. string instead of
+    numbers)
 
-    * [204] HTTP Status 400: Data value enumeration unknown
+    * [204] HTTP Status 400: Unknown enumeration value
 
-    * [205] HTTP Status 400: Data value out of range
-      - Remark: Exceeds the minimum or maximum value
+    * [205] HTTP Status 400: Value out of range (exceeds the minimum or maximum
+    value)
 
-    * [206] HTTP Status 400: Data value out of bounds
-      - Remark: An array/string was accessed exceeding its maximum length
+    * [206] HTTP Status 400: Out of bounds (an array/string was accessed
+    exceeding its maximum length)
 
-    * [207] HTTP Status 400: deviceAlias is not unique
+    * [207] HTTP Status 400: Duplicated deviceAlias
+
 
     ### Resource access errors
 
-    * [301] HTTP Status 404: Resource not found
+    * [301] HTTP Status 404: Resource not found (e.g. wrong URL).
 
     * [302] HTTP Status 404: masterNumber not found
 
@@ -54,34 +54,41 @@ info:
 
     * [304] HTTP Status 404: deviceAlias not found
 
-    * [305] HTTP Status 400: Query parameter name invalid
+    * [305] HTTP Status 400: Incorrect query parameter name
 
-    * [306] HTTP Status 400: Query parameter value invalid
+    * [306] HTTP Status 400: Incorrect query parameter value
 
-    * [307] HTTP Status 400: Port is not configured for IO-Link
+    * [307] HTTP Status 400: Port is not configured in IOLINK_MANUAL or
+    IOLINK_AUTOSTART mode.
 
-    * [308] HTTP Status 404: IO-Link Device is not accessible
+    * [308] HTTP Status 404: IO-Link Device is not accessible (not connected or
+    communication error)
 
     * [309] HTTP Status 404: IO-Link parameter not found
 
-    * [310] HTTP Status 404: IO-Link parameter access not supported
+    * [310] HTTP Status 404: IO-Link parameter access not supported by the Device
 
     * [311] HTTP Status 400: IO-Link parameter access error
       - Remark: The additional  iolinkErrorCode and iolinkErrorMessage fields contain
       the IO-Link error code and the incident text from the ErrorTypes table
 
-    * [312] HTTP Status 404: IO-Link parameter name is not unique.
+    * [312] HTTP Status 404: IO-Link parameter name is not unique. Please use the
+      [name]_[index] format.
+
 
     ### Data Storage errors
 
-    * [401] HTTP Status 400: Data storage mismatch
-      - Remark: mismatch between meta data of device and data storage
+    * [401] HTTP Status 400: Mismatch between configured device and data storage
+    meta data
+
 
     ### Process Data handling
 
-    * [501] HTTP Status 400: Writing processData not possible. Pin 2 is no DIGITAL_OUTPUT
+    * [501] HTTP Status 400: Writing processdata to Pin 2 is not possible. Pin 2
+    is not configured as DIGITAL_OUTPUT
 
-    * [502] HTTP Status 400: Writing processData not possible. Pin 4 is no DIGITAL_OUTPUT
+    * [502] HTTP Status 400: Writing processdata to Pin 4 is not possible. Pin 4
+    is not configured as DIGITAL_OUTPUT
 
     * [503] HTTP Status 400: Attached IO-Link device has no output process data
 
@@ -90,27 +97,30 @@ info:
 
     * [601] HTTP Status 400: IODD is not available.
 
-    * [602] HTTP Status 500: IODD upload failed: not enough memory
+    * [602] HTTP Status 500: Unable to upload IODD XML file. Insufficient memory
+    space
 
-    * [603] HTTP Status 400: IODD upload failed: IODD XML invalid
+    * [603] HTTP Status 400: Uploaded file is no valid IODD XML. Upload rejected
       - Remark: We could check the file content superficially to ensure that the
       IODD is an XML and an IODD (e.g. vendorId, deviceId, VendorName, ProductName
       and other mandatory elements or attributes)
 
-    * [604] HTTP Status 400: IODD upload failed: CRC error
+    * [604] HTTP Status 400: Uploaded file is no valid IODD XML. CRC check
+    failed. Upload rejected
 
-    * [605] HTTP Status 400: IODD upload failed: parsing error
+    * [605] HTTP Status 400: Uploaded file is no valid IODD XML. Parsing
+    failed. Upload rejected
       - Remark: All those systems that do not want to store the IODD have to parse
       it immediately
 
 
     ### Data content errors
 
-    * [701] HTTP Status 400: Data set incomplete
+    * [701] HTTP Status 400: Incomplete data set
 
-    * [702] HTTP Status 400: Data set not applicable
+    * [702] HTTP Status 400: Data set not applicable (not supported), the whole data set is rejected
 
-    * [703] HTTP Status 400: Data set combination is incompatible
+    * [703] HTTP Status 400: Incompatible data set combination, the whole data set is rejected
 
 
 
@@ -5891,4 +5901,3 @@ components:
                 type: string
               iolError:
                 type: integer
-

--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -16,37 +16,40 @@ info:
 
     * [103] HTTP Status 404: Operation not supported
 
-    * [104] HTTP Status 400: Action locked by another client (e.g. fieldbus
-    controller)
+    * [104] HTTP Status 400: Action locked by another client
+      - Remark: Fieldbus controller or another gateway protocol has claimed priority
 
-    * [150] HTTP Status 403: Permission denied (e.g. user management)
+    * [150] HTTP Status 403: Permission denied
+      - Remark: due to user management restrictions
 
 
     ### JSON Parsing errors
 
-    * [201] HTTP Status 400: Parsing failed (error while parsing the incoming
-    JSON value)
+    * [201] HTTP Status 400: Parsing failed
+      - Remark: Error while parsing the incoming JSON object
 
-    * [202] HTTP Status 400: Invalid data (given for the value, e.g. malformed
-    IP address)
+    * [202] HTTP Status 400: Data value invalid
+      - Remark: Error while parsing a specific JSON value, e.g. malformed IP address
 
-    * [203] HTTP Status 400: Invalid JSON data type (e.g. string instead of
-    numbers)
+    * [203] HTTP Status 400: Data type invalid
+      - Remark: e.g. string instead of number
 
-    * [204] HTTP Status 400: Unknown enumeration value
+    * [204] HTTP Status 400: Enumeration value unknown
 
-    * [205] HTTP Status 400: Value out of range (exceeds the minimum or maximum
-    value)
+    * [205] HTTP Status 400: Data value out of range
+      - Remark: Exceeds the minimum or maximum value
 
-    * [206] HTTP Status 400: Out of bounds (an array/string was accessed
-    exceeding its maximum length)
+    * [206] HTTP Status 400: Data value out of bounds
+      - Remark: An array/string was accessed exceeding its maximum length
 
-    * [207] HTTP Status 400: Duplicated deviceAlias
-
+    * [207] HTTP Status 400: deviceAlias is not unique
+    
+    * [208] HTTP Status 400: POST request without content
 
     ### Resource access errors
 
-    * [301] HTTP Status 404: Resource not found (e.g. wrong URL).
+    * [301] HTTP Status 404: Resource not found
+      - Remark: wrong URL
 
     * [302] HTTP Status 404: masterNumber not found
 
@@ -54,74 +57,66 @@ info:
 
     * [304] HTTP Status 404: deviceAlias not found
 
-    * [305] HTTP Status 400: Incorrect query parameter name
+    * [305] HTTP Status 400: Query parameter name invalid
 
-    * [306] HTTP Status 400: Incorrect query parameter value
+    * [306] HTTP Status 400: Query parameter value invalid
 
-    * [307] HTTP Status 400: Port is not configured in IOLINK_MANUAL or
-    IOLINK_AUTOSTART mode.
+    * [307] HTTP Status 400: Port is not configured for IO-Link
+      - Remark: e.g. not in IOLINK_MANUAL or IOLINK_AUTOSTART mode
 
-    * [308] HTTP Status 404: IO-Link Device is not accessible (not connected or
-    communication error)
+    * [308] HTTP Status 404: IO-Link Device is not accessible
+      - Remark: e.g. not connected or communication error
 
     * [309] HTTP Status 404: IO-Link parameter not found
 
-    * [310] HTTP Status 404: IO-Link parameter access not supported by the Device
+    * [310] HTTP Status 404: IO-Link parameter access not supported by the device
 
     * [311] HTTP Status 400: IO-Link parameter access error
-      - Remark: The additional  iolinkErrorCode and iolinkErrorMessage fields contain
+      - Remark: The additional iolinkErrorCode and iolinkErrorMessage fields contain
       the IO-Link error code and the incident text from the ErrorTypes table
 
-    * [312] HTTP Status 404: IO-Link parameter name is not unique. Please use the
-      [name]_[index] format.
-
+    * [312] HTTP Status 404: IO-Link parameter name is not unique.
+      - Remark: Please use the {name}_{index} format
 
     ### Data Storage errors
 
-    * [401] HTTP Status 400: Mismatch between configured device and data storage
-    meta data
-
+    * [401] HTTP Status 400: Data storage mismatch
+      - Remark: Mismatch between meta data of device and data storage
 
     ### Process Data handling
 
-    * [501] HTTP Status 400: Writing processdata to Pin 2 is not possible. Pin 2
-    is not configured as DIGITAL_OUTPUT
+    * [501] HTTP Status 400: I/Q is not configured as DIGITAL_OUTPUT
 
-    * [502] HTTP Status 400: Writing processdata to Pin 4 is not possible. Pin 4
-    is not configured as DIGITAL_OUTPUT
+    * [502] HTTP Status 400: C/Q is not configured as DIGITAL_OUTPUT
 
-    * [503] HTTP Status 400: Attached IO-Link device has no output process data
+    * [503] HTTP Status 400: IO-Link device has no output process data
 
 
     ### IODD errors
 
-    * [601] HTTP Status 400: IODD is not available.
+    * [601] HTTP Status 400: IODD (representation) for this IO-Link device is not available
 
-    * [602] HTTP Status 500: Unable to upload IODD XML file. Insufficient memory
-    space
+    * [602] HTTP Status 500: IODD upload failed. Not enough memory
 
-    * [603] HTTP Status 400: Uploaded file is no valid IODD XML. Upload rejected
-      - Remark: We could check the file content superficially to ensure that the
+    * [603] HTTP Status 400: IODD upload failed: IODD XML invalid
+      - Remark: Check the file content superficially to ensure that the
       IODD is an XML and an IODD (e.g. vendorId, deviceId, VendorName, ProductName
       and other mandatory elements or attributes)
 
-    * [604] HTTP Status 400: Uploaded file is no valid IODD XML. CRC check
-    failed. Upload rejected
+    * [604] HTTP Status 400: IODD upload failed. CRC error
 
-    * [605] HTTP Status 400: Uploaded file is no valid IODD XML. Parsing
-    failed. Upload rejected
+    * [605] HTTP Status 400: IODD upload failed. Parsing error
       - Remark: All those systems that do not want to store the IODD have to parse
       it immediately
 
 
     ### Data content errors
 
-    * [701] HTTP Status 400: Incomplete data set
+    * [701] HTTP Status 400: Data set incomplete
 
-    * [702] HTTP Status 400: Data set not applicable (not supported), the whole data set is rejected
+    * [702] HTTP Status 400: Data set not applicable
 
-    * [703] HTTP Status 400: Incompatible data set combination, the whole data set is rejected
-
+    * [703] HTTP Status 400: Data set combination incompatible
 
 
     ### Implementation hints:

--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -16,37 +16,38 @@ info:
 
     * [103] HTTP Status 404: Operation not supported
 
-    * [104] HTTP Status 400: Action locked by another client (e.g. fieldbus
-    controller)
+    * [104] HTTP Status 400: Action locked by another client
+      - Remark: Fieldbus controller or another gateway protocol has claimed priority
 
-    * [150] HTTP Status 403: Permission denied (e.g. user management)
+    * [150] HTTP Status 403: Permission denied
+      - Remark: e.g. by  user management
 
 
     ### JSON Parsing errors
 
-    * [201] HTTP Status 400: Parsing failed (error while parsing the incoming
-    JSON value)
+    * [201] HTTP Status 400: Parsing failed
+      - Remark: Error while parsing the incoming JSON value
 
-    * [202] HTTP Status 400: Invalid data (given for the value, e.g. malformed
-    IP address)
+    * [202] HTTP Status 400: Data value invalid
+      - Remark: given for the value, e.g. malformed IP address
 
-    * [203] HTTP Status 400: Invalid JSON data type (e.g. string instead of
-    numbers)
+    * [203] HTTP Status 400: Data type invalid
+      - Remark: e.g. string instead of number
 
-    * [204] HTTP Status 400: Unknown enumeration value
+    * [204] HTTP Status 400: Data value enumeration unknown
 
-    * [205] HTTP Status 400: Value out of range (exceeds the minimum or maximum
-    value)
+    * [205] HTTP Status 400: Data value out of range
+      - Remark: Exceeds the minimum or maximum value
 
-    * [206] HTTP Status 400: Out of bounds (an array/string was accessed
-    exceeding its maximum length)
+    * [206] HTTP Status 400: Data value out of bounds
+      - Remark: An array/string was accessed exceeding its maximum length
 
-    * [207] HTTP Status 400: Duplicated deviceName
+    * [207] HTTP Status 400: deviceName is not unique
 
 
     ### Resource access errors
 
-    * [301] HTTP Status 404: Resource not found (e.g. wrong URL).
+    * [301] HTTP Status 404: Resource not found
 
     * [302] HTTP Status 404: masterNumber not found
 
@@ -54,41 +55,34 @@ info:
 
     * [304] HTTP Status 404: deviceName not found
 
-    * [305] HTTP Status 400: Incorrect query parameter name
+    * [305] HTTP Status 400: Query parameter name invalid
 
-    * [306] HTTP Status 400: Incorrect query parameter value
+    * [306] HTTP Status 400: Query parameter value invalid
 
-    * [307] HTTP Status 400: Port is not configured in IOLINK_MANUAL or
-    IOLINK_AUTOSTART mode.
+    * [307] HTTP Status 400: Port is not configured for IO-Link
 
-    * [308] HTTP Status 404: IO-Link Device is not accessible (not connected or
-    communication error)
+    * [308] HTTP Status 404: IO-Link Device is not accessible
 
     * [309] HTTP Status 404: IO-Link parameter not found
 
-    * [310] HTTP Status 404: IO-Link parameter access not supported by the Device
+    * [310] HTTP Status 404: IO-Link parameter access not supported
 
     * [311] HTTP Status 400: IO-Link parameter access error
       - Remark: The additional  iolinkErrorCode and iolinkErrorMessage fields contain
       the IO-Link error code and the incident text from the ErrorTypes table
 
-    * [312] HTTP Status 404: IO-Link parameter name is not unique. Please use the
-      [name]_[index] format.
-
+    * [312] HTTP Status 404: IO-Link parameter name is not unique.
 
     ### Data Storage errors
 
-    * [401] HTTP Status 400: Mismatch between configured device and data storage
-    meta data
-
+    * [401] HTTP Status 400: Data storage mismatch
+      - Remark: mismatch between meta data of device and data storage
 
     ### Process Data handling
 
-    * [501] HTTP Status 400: Writing processdata to Pin 2 is not possible. Pin 2
-    is not configured as DIGITAL_OUTPUT
+    * [501] HTTP Status 400: Writing processData not possible. Pin 2 is no DIGITAL_OUTPUT
 
-    * [502] HTTP Status 400: Writing processdata to Pin 4 is not possible. Pin 4
-    is not configured as DIGITAL_OUTPUT
+    * [502] HTTP Status 400: Writing processData not possible. Pin 4 is no DIGITAL_OUTPUT
 
     * [503] HTTP Status 400: Attached IO-Link device has no output process data
 
@@ -97,30 +91,27 @@ info:
 
     * [601] HTTP Status 400: IODD is not available.
 
-    * [602] HTTP Status 500: Unable to upload IODD XML file. Insufficient memory
-    space
+    * [602] HTTP Status 500: IODD upload failed: not enough memory
 
-    * [603] HTTP Status 400: Uploaded file is no valid IODD XML. Upload rejected
+    * [603] HTTP Status 400: IODD upload failed: IODD XML invalid
       - Remark: We could check the file content superficially to ensure that the
       IODD is an XML and an IODD (e.g. vendorId, deviceId, VendorName, ProductName
       and other mandatory elements or attributes)
 
-    * [604] HTTP Status 400: Uploaded file is no valid IODD XML. CRC check
-    failed. Upload rejected
+    * [604] HTTP Status 400: IODD upload failed: CRC error
 
-    * [605] HTTP Status 400: Uploaded file is no valid IODD XML. Parsing
-    failed. Upload rejected
+    * [605] HTTP Status 400: IODD upload failed: parsing error
       - Remark: All those systems that do not want to store the IODD have to parse
       it immediately
 
 
     ### Data content errors
 
-    * [701] HTTP Status 400: Incomplete data set
+    * [701] HTTP Status 400: Data set incomplete
 
-    * [702] HTTP Status 400: Data set not applicable (not supported), the whole data set is rejected
+    * [702] HTTP Status 400: Data set not applicable
 
-    * [703] HTTP Status 400: Incompatible data set combination, the whole data set is rejected
+    * [703] HTTP Status 400: Data set combination is incompatible
 
 
 
@@ -142,7 +133,7 @@ info:
 
     * If the request was successful and no body is specified, the response
     contains nothing in the body.
-  version: 0.0.9
+  version: 0.0.10
   title: Swagger IO-Link Master
   contact:
     email: lorand.molnar@teconcept.de
@@ -188,7 +179,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -197,7 +188,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -227,7 +218,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -236,7 +227,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -262,11 +253,11 @@ paths:
                 Manual:
                   value:
                     ethIpv4: [
-                      { 
+                      {
                         ipConfiguration: MANUAL,
                         ipAddress: 192.168.1.13,
                         subnetMask: 255.255.255.0,
-                        standardGateway: 192.168.1.1   
+                        standardGateway: 192.168.1.1
                       }
                     ]
                 DHCP:
@@ -276,7 +267,7 @@ paths:
                         ipConfiguration: DHCP,
                         ipAddress: 192.168.100.5,
                         subnetMask: 255.255.255.0,
-                        standardGateway: 192.168.100.1  
+                        standardGateway: 192.168.100.1
                       }
                     ]
                 Multiple ethernet interfaces:
@@ -286,19 +277,19 @@ paths:
                         ipConfiguration: MANUAL,
                         ipAddress: 192.168.1.13,
                         subnetMask: 255.255.255.0,
-                        standardGateway: 192.168.1.1   
+                        standardGateway: 192.168.1.1
                       },
                       {
                         ipConfiguration: MANUAL,
                         ipAddress: 192.168.2.10,
                         subnetMask: 255.255.255.0,
-                        standardGateway: 192.168.2.1  
+                        standardGateway: 192.168.2.1
                       },
                       {
                         ipConfiguration: DHCP,
                         ipAddress: 192.168.200.7,
                         subnetMask: 255.255.255.0,
-                        standardGateway: 192.168.200.1  
+                        standardGateway: 192.168.200.1
                       }
                     ]
         '400':
@@ -309,7 +300,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -318,7 +309,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -342,11 +333,11 @@ paths:
               Manual:
                 value:
                   ethIpv4: [
-                    { 
+                    {
                       ipConfiguration: MANUAL,
                       ipAddress: 192.168.1.13,
                       subnetMask: 255.255.255.0,
-                      standardGateway: 192.168.1.1   
+                      standardGateway: 192.168.1.1
                     }
                   ]
               DHCP:
@@ -363,13 +354,13 @@ paths:
                       ipConfiguration: MANUAL,
                       ipAddress: 192.168.1.13,
                       subnetMask: 255.255.255.0,
-                      standardGateway: 192.168.1.1   
+                      standardGateway: 192.168.1.1
                     },
                     {
                       ipConfiguration: MANUAL,
                       ipAddress: 192.168.2.10,
                       subnetMask: 255.255.255.0,
-                      standardGateway: 192.168.2.1  
+                      standardGateway: 192.168.2.1
                     },
                     {
                       ipConfiguration: DHCP
@@ -386,23 +377,23 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 104
-                  message: Action locked by another client (e.g. fieldbuscontroller)
+                  message: Action locked by another client
                 - msgCode: 201
-                  message: Parsing failed (error while parsing the incoming JSON value)
+                  message: Parsing failed
                 - msgCode: 202
-                  message: Invalid data (given for the value, e.g. malformed IP address)
+                  message: Data value invalid
                 - msgCode: 203
-                  message: Invalid JSON data type (e.g. string instead of numbers)
+                  message: Data type invalid
                 - msgCode: 204
-                  message: Unknown enumeration value
+                  message: Enumeration value unknown
                 - msgCode: 205
-                  message: Value out of range (exceeds the minimum or maximum value)
+                  message: Data value out of range
                 - msgCode: 206
-                  message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                  message: Data value out of bounds
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
                 - msgCode: 701
-                  message: Incomplete data set
+                  message: Data set incomplete
         '403':
           description: Forbidden
           content:
@@ -411,7 +402,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -437,9 +428,9 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 104
-                  message: Action locked by another client (e.g. fieldbuscontroller)
+                  message: Action locked by another client
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -448,7 +439,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -474,9 +465,9 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 104
-                  message: Action locked by another client (e.g. fieldbuscontroller)
+                  message: Action locked by another client
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -485,7 +476,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -649,7 +640,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -658,7 +649,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -708,7 +699,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -717,7 +708,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -777,21 +768,21 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 104
-                  message: Action locked by another client (e.g. fieldbus controller)
+                  message: Action locked by another client
                 - msgCode: 201
-                  message: Parsing failed (error while parsing the incoming JSON value)
+                  message: Parsing failed
                 - msgCode: 202
-                  message: Invalid data (given for the value, e.g. malformed IP address)
+                  message: Data value invalid
                 - msgCode: 203
-                  message: Invalid JSON data type (e.g. string instead of numbers)
+                  message: Data type invalid
                 - msgCode: 204
-                  message: Unknown enumeration value
+                  message: Data value enumeration unknown
                 - msgCode: 205
-                  message: Value out of range (exceeds the minimum or maximum value)
+                  message: Data value out of range
                 - msgCode: 206
-                  message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                  message: Data value out of bounds
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
                 - msgCode: 701
                   message: Incomplete data set
         '403':
@@ -802,7 +793,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -867,7 +858,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -876,7 +867,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -944,19 +935,19 @@ paths:
                 - msgCode: 104
                   message: Action locked by another client
                 - msgCode: 201
-                  message: Parsing failed (error while parsing the incoming JSON value)
+                  message: Parsing failed
                 - msgCode: 202
-                  message: Invalid data (given for the value, e.g. malformed IP address)
+                  message: Data value invalid
                 - msgCode: 203
-                  message: Invalid JSON data type (e.g. string instead of numbers)
+                  message: Data type invalid
                 - msgCode: 204
-                  message: Unknown enumeration value
+                  message: Data value enumeration unknown
                 - msgCode: 205
-                  message: Value out of range (exceeds the minimum or maximum value)
+                  message: Data value out of range
                 - msgCode: 206
-                  message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                  message: Data value out of bounds
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
                 - msgCode: 701
                   message: Incomplete data set
         '403':
@@ -967,7 +958,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1032,7 +1023,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1041,7 +1032,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1052,7 +1043,7 @@ paths:
                 - msgCode: 103
                   message: Operation not supported
                 - msgCode: 301
-                  message: Resource not found (e.g. wrong URL)
+                  message: Resource not found
         '500':
           description: Internal server error
           content:
@@ -1081,7 +1072,7 @@ paths:
                 - msgCode: 104
                   message: Action locked by another client
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1090,7 +1081,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1101,7 +1092,7 @@ paths:
                 - msgCode: 103
                   message: Operation not supported
                 - msgCode: 301
-                  message: Resource not found (e.g. wrong URL)
+                  message: Resource not found
         '500':
           description: Internal server error
           content:
@@ -1136,7 +1127,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1145,7 +1136,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1192,13 +1183,13 @@ paths:
                 - msgCode: 104
                   message: Action locked by another client
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
                 - msgCode: 603
-                  message: Uploaded file is no valid IODD XML. Upload rejected
+                  message: 'IODD upload failed: IODD XML invalid'
                 - msgCode: 604
-                  message: Uploaded file is no valid IODD XML. CRC check failed
+                  message: 'IODD upload failed: CRC error'
                 - msgCode: 605
-                  message: Uploaded file is no valid IODD XML. Parsing failed
+                  message: 'IODD upload failed: Parsing failed'
         '403':
           description: Forbidden
           content:
@@ -1207,7 +1198,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1255,7 +1246,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1264,7 +1255,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1275,7 +1266,7 @@ paths:
                 - msgCode: 103
                   message: Operation not supported
                 - msgCode: 301
-                  message: Resource not found (e.g. wrong URL)
+                  message: Resource not found
         '500':
           description: Internal server error
           content:
@@ -1310,7 +1301,7 @@ paths:
                 - msgCode: 104
                   message: Action locked by another client
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1319,7 +1310,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1330,7 +1321,7 @@ paths:
                 - msgCode: 103
                   message: Operation not supported
                 - msgCode: 301
-                  message: Resource not found (e.g. wrong URL)
+                  message: Resource not found
         '500':
           description: Internal server error
           content:
@@ -1362,7 +1353,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1371,7 +1362,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -1413,7 +1404,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Bad request
           content:
@@ -1464,17 +1455,17 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 104
-                  message: Action locked by another client (e.g. fieldbus controller)
+                  message: Action locked by another client
                 - msgCode: 201
-                  message: Parsing failed (error while parsing the incoming JSON value)
+                  message: Parsing failed
                 - msgCode: 202
-                  message: Invalid data (given for the value, e.g. malformed IP address)
+                  message: Data value invalid
                 - msgCode: 203
-                  message: Invalid JSON data type (e.g. string instead of numbers)
+                  message: Data type invalid
                 - msgCode: 206
-                  message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                  message: Data value out of bounds
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1483,7 +1474,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1526,7 +1517,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1535,7 +1526,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1591,7 +1582,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1600,7 +1591,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1644,7 +1635,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1653,7 +1644,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1699,7 +1690,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1708,7 +1699,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1769,25 +1760,25 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 104
-                  message: Action locked by another client (e.g. fieldbus controller)
+                  message: Action locked by another client
                 - msgCode: 201
-                  message: Parsing failed (error while parsing the incoming JSON value)
+                  message: Parsing failed
                 - msgCode: 202
-                  message: Invalid data (given for the value, e.g. malformed IP address)
+                  message: Data value invalid
                 - msgCode: 203
-                  message: Invalid JSON data type (e.g. string instead of numbers)
+                  message: Data type invalid
                 - msgCode: 204
-                  message: Unknown enumeration value
+                  message: Data value enumeration unknown
                 - msgCode: 205
-                  message: Value out of range (exceeds the minimum or maximum value)
+                  message: Data value out of range
                 - msgCode: 207
-                  message: Duplicated Device Name
+                  message: deviceName is not unique
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
                 - msgCode: 702
-                  message: Data set not applicable (not supported), the whole data set is rejected
+                  message: Data set not applicable
                 - msgCode: 703
-                  message: Incompatible data set combination, the whole data set is rejected
+                  message: Data set combination is incompatible
         '403':
           description: Forbidden
           content:
@@ -1796,7 +1787,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1842,7 +1833,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1851,7 +1842,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1912,7 +1903,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -1921,7 +1912,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -1983,23 +1974,23 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 104
-                  message: Action locked by another client (e.g. fieldbus controller)
+                  message: Action locked by another client
                 - msgCode: 201
-                  message: Parsing failed (error while parsing the incoming JSON value)
+                  message: Parsing failed
                 - msgCode: 202
-                  message: Invalid data (given for the value, e.g. malformed IP address)
+                  message: Data value invalid
                 - msgCode: 203
-                  message: Invalid JSON data type (e.g. string instead of numbers)
+                  message: Data type invalid
                 - msgCode: 204
-                  message: Unknown enumeration value
+                  message: Data value enumeration unknown
                 - msgCode: 205
-                  message: Value out of range (exceeds the minimum or maximum value)
+                  message: Data value out of range
                 - msgCode: 206
-                  message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                  message: Data value out of bounds
                 - msgCode: 305
-                  message: Incorrect query parameter name
+                  message: Query parameter name invalid
                 - msgcode: 401
-                  message: Mismatch between configured device and data storage meta data
+                  message: Data storage mismatch
                 - msgCode: 701
                   message: Incomplete data set
         '403':
@@ -2010,7 +2001,7 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - msgCode: 150
-                  message: Permission denied (e.g. user management)
+                  message: Permission denied
         '404':
           description: Not found
           content:
@@ -2081,7 +2072,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
         '403':
           description: Forbidden
           content:
@@ -2090,7 +2081,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -2128,9 +2119,9 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
         '403':
           description: Forbidden
           content:
@@ -2139,7 +2130,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2150,7 +2141,7 @@ paths:
                 - msgCode: 304
                   message: deviceName not found
                 - msgCode: 308
-                  message: IO-Link Device is not accessible (not connected or communication error)
+                  message: IO-Link Device is not accessible
         '500':
           description: Internal server error
           content:
@@ -2192,19 +2183,19 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 104
-                    message: Action locked by another client (e.g. fieldbus controller)
+                    message: Action locked by another client
                   - msgCode: 201
-                    message: Parsing failed (error while parsing the incoming JSON value)
+                    message: Parsing failed
                   - msgCode: 202
-                    message: Invalid data (given for the value, e.g. malformed IP address)
+                    message: Data value invalid
                   - msgCode: 203
-                    message: Invalid JSON data type (e.g. string instead of numbers)
+                    message: Data type invalid
                   - msgCode: 206
-                    message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                    message: Data value out of bounds
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
         '403':
           description: Forbidden
           content:
@@ -2213,7 +2204,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2224,7 +2215,7 @@ paths:
                   - msgCode: 304
                     message: deviceName not found
                   - msgCode: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
                   - msgCode: 309
                     message: IO-Link parameter not found
                   - msgCode: 310
@@ -2266,9 +2257,9 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
         '404':
           description: Not found
           content:
@@ -2279,7 +2270,7 @@ paths:
                 - msgCode: 304
                   message: deviceName not found
                 - msgCode: 308
-                  message: IO-Link Device is not accessible (not connected or communication error)
+                  message: IO-Link Device is not accessible
         '500':
           description: Internal server error
           content:
@@ -2376,9 +2367,9 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 306
-                    message: Incorrect query parameter value
+                    message: Query parameter value invalid
                   - msgCode: 601
                     message: IODD is not available
         '403':
@@ -2389,7 +2380,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2468,35 +2459,35 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 104
-                    message: Action locked by another client (e.g. fieldbus controller)
+                    message: Action locked by another client
                   - msgCode: 201
-                    message: Parsing failed (error while parsing the incoming JSON value)
+                    message: Parsing failed
                   - msgCode: 202
-                    message: Invalid data (given for the value, e.g. malformed IP address)
+                    message: Data value invalid
                   - msgCode: 203
-                    message: Invalid JSON data type (e.g. string instead of numbers)
+                    message: Data type invalid
                   - msgCode: 204
-                    message: Unknown enumeration value
+                    message: Data value enumeration unknown
                   - msgCode: 205
-                    message: Value out of range (exceeds the minimum or maximum value)
+                    message: Data value out of range
                   - msgCode: 206
-                    message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                    message: Data value out of bounds
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgcode: 306
-                    message: Incorrect query parameter value
+                    message: Query parameter value invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
                   - msgCode: 501
-                    message: Writing processdata to Pin 2 is not possible. Pin 2 is not configured as DIGITAL_OUTPUT
+                    message: Writing processData not possible. Pin 2 is no DIGITAL_OUTPUT
                   - msgCode: 502
-                    message: Writing processdata to Pin 4 is not possible. Pin 4 is not configured as DIGITAL_OUTPUT
+                    message: Writing processData not possible. Pin 4 is no DIGITAL_OUTPUT
                   - msgCode: 503
                     message: Attached IO-Link device has no output process data
                   - msgCode: 601
                     message: IODD is not available
                   - msgCode: 703
-                    message: Incompatible data set combination, the whole data set is rejected
+                    message: Data set combination is incompatible
         '403':
           description: Forbidden
           content:
@@ -2505,7 +2496,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2518,7 +2509,7 @@ paths:
                   - msgCode: 304
                     message: deviceName not found
                   - msgCode: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
         '500':
           description: Internal server error
           content:
@@ -2554,7 +2545,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 601
                     message: IODD is not available
         '403':
@@ -2565,7 +2556,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2625,7 +2616,7 @@ paths:
                       "value": 12
                     }
                   }
-                  
+
         '400':
           description: Bad request
           content:
@@ -2634,11 +2625,11 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 306
-                    message: Incorrect query parameter value
+                    message: Query parameter value invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
                   - msgCode: 311
                     message: IO-Link parameter access error
                   - msgCode: 601
@@ -2651,7 +2642,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2664,7 +2655,7 @@ paths:
                   - msgCode: 304
                     message: deviceName not found
                   - msgCode: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
                   - msgCode: 309
                     message: IO-Link parameter not found
         '500':
@@ -2725,31 +2716,31 @@ paths:
                   - msgCode: 103
                     message: Operation not supported
                   - msgCode: 104
-                    message: Action locked by another client (e.g. fieldbus controller)
+                    message: Action locked by another client
                   - msgCode: 201
-                    message: Parsing failed (error while parsing the incoming JSON value)
+                    message: Parsing failed
                   - msgCode: 202
-                    message: Invalid data (given for the value, e.g. malformed IP address)
+                    message: Data value invalid
                   - msgCode: 203
-                    message: Invalid JSON data type (e.g. string instead of numbers)
+                    message: Data type invalid
                   - msgCode: 204
-                    message: Unknown enumeration value
+                    message: Data value enumeration unknown
                   - msgCode: 205
-                    message: Value out of range (exceeds the minimum or maximum value)
+                    message: Data value out of range
                   - msgCode: 206
-                    message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                    message: Data value out of bounds
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 306
-                    message: Incorrect query parameter value
+                    message: Query parameter value invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
                   - msgCode: 311
                     message: IO-Link parameter access error
                   - msgCode: 601
                     message: IODD is not available
                   - msgCode: 703
-                    message: Incompatible data set combination, the whole data set is rejected
+                    message: Data set combination is incompatible
         '403':
           description: Forbidden
           content:
@@ -2758,7 +2749,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2769,7 +2760,7 @@ paths:
                   - msgCode: 304
                     message: deviceName not found
                   - msgCode: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
                   - msgCode: 309
                     message: IO-Link parameter not found
         '500':
@@ -2830,11 +2821,11 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 306
-                    message: Incorrect query parameter value
+                    message: Query parameter value invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
                   - msgCode: 311
                     message: IO-Link parameter access error
                   - msgCode: 601
@@ -2847,7 +2838,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2860,7 +2851,7 @@ paths:
                   - msgCode: 304
                     message: deviceName not found
                   - msgCode: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
                   - msgCode: 309
                     message: IO-Link parameter not found
                   - msgCode: 312
@@ -2923,31 +2914,31 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 104
-                    message: Action locked by another client (e.g. fieldbus controller)
+                    message: Action locked by another client
                   - msgCode: 201
-                    message: Parsing failed (error while parsing the incoming JSON value)
+                    message: Parsing failed
                   - msgCode: 202
-                    message: Invalid data (given for the value, e.g. malformed IP address)
+                    message: Data value invalid
                   - msgCode: 203
-                    message: Invalid JSON data type (e.g. string instead of numbers)
+                    message: Data type invalid
                   - msgCode: 204
-                    message: Unknown enumeration value
+                    message: Data value enumeration unknown
                   - msgCode: 205
-                    message: Value out of range (exceeds the minimum or maximum value)
+                    message: Data value out of range
                   - msgCode: 206
-                    message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                    message: Data value out of bounds
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 306
-                    message: Incorrect query parameter value
+                    message: Query parameter value invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
                   - msgCode: 311
                     message: IO-Link parameter access error
                   - msgCode: 601
                     message: IODD is not available
                   - msgCode: 703
-                    message: Incompatible data set combination, the whole data set is rejected
+                    message: Data set combination is incompatible
         '403':
           description: Forbidden
           content:
@@ -2956,7 +2947,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2969,7 +2960,7 @@ paths:
                   - msgCode: 304
                     message: deviceName not found
                   - msgCode: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
                   - msgCode: 309
                     message: IO-Link parameter not found
                   - msgCode: 312
@@ -3010,7 +3001,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 601
                     message: IODD is not available
         '403':
@@ -3021,7 +3012,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -3071,7 +3062,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 601
                     message: IODD is not available
         '403':
@@ -3082,7 +3073,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -3147,11 +3138,11 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 306
-                    message: Incorrect query parameter value
+                    message: Query parameter value invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
                   - msgCode: 311
                     message: IO-Link parameter access error
                   - msgCode: 601
@@ -3164,7 +3155,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -3177,7 +3168,7 @@ paths:
                   - msgCode: 304
                     message: deviceName not found
                   - msgCode: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
                   - msgCode: 309
                     message: IO-Link parameter not found
         '500':
@@ -3229,31 +3220,31 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 104
-                    message: Action locked by another client (e.g. fieldbus controller)
+                    message: Action locked by another client
                   - msgCode: 201
-                    message: Parsing failed (error while parsing the incoming JSON value)
+                    message: Parsing failed
                   - msgCode: 202
-                    message: Invalid data (given for the value, e.g. malformed IP address)
+                    message: Data value invalid
                   - msgCode: 203
-                    message: Invalid JSON data type (e.g. string instead of numbers)
+                    message: Data type invalid
                   - msgCode: 204
-                    message: Unknown enumeration value
+                    message: Data value enumeration unknown
                   - msgCode: 205
-                    message: Value out of range (exceeds the minimum or maximum value)
+                    message: Data value out of range
                   - msgCode: 206
-                    message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                    message: Data value out of bounds
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 306
-                    message: Incorrect query parameter value
+                    message: Query parameter value invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
                   - msgCode: 311
                     message: IO-Link parameter access error
                   - msgCode: 601
                     message: IODD is not availabl
                   - msgCode: 703
-                    message: Incompatible data set combination, the whole data set is rejected
+                    message: Data set combination is incompatible
         '403':
           description: Forbidden
           content:
@@ -3262,7 +3253,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -3275,7 +3266,7 @@ paths:
                   - msgCode: 304
                     message: deviceName not found
                   - msgCode: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
                   - msgCode: 309
                     message: IO-Link parameter not found
         '500':
@@ -3328,11 +3319,11 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 306
-                    message: Incorrect query parameter value
+                    message: Query parameter value invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
                   - msgCode: 311
                     message: IO-Link parameter access error
                   - msgCode: 601
@@ -3345,7 +3336,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -3358,7 +3349,7 @@ paths:
                   - msgCode: 304
                     message: deviceName not found
                   - msgCode: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
                   - msgCode: 309
                     message: IO-Link parameter not found
                   - msgCode: 312
@@ -3414,31 +3405,31 @@ paths:
                   - msgCode: 103
                     message: Operation not supported
                   - msgCode: 104
-                    message: Action locked by another client (e.g. fieldbus controller)
+                    message: Action locked by another client
                   - msgCode: 201
-                    message: Parsing failed (error while parsing the incoming JSON value)
+                    message: Parsing failed
                   - msgCode: 202
-                    message: Invalid data (given for the value, e.g. malformed IP address)
+                    message: Data value invalid
                   - msgCode: 203
-                    message: Invalid JSON data type (e.g. string instead of numbers)
+                    message: Data type invalid
                   - msgCode: 204
-                    message: Unknown enumeration value
+                    message: Data value enumeration unknown
                   - msgCode: 205
-                    message: Value out of range (exceeds the minimum or maximum value)
+                    message: Data value out of range
                   - msgCode: 206
-                    message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                    message: Data value out of bounds
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 306
-                    message: Incorrect query parameter value
+                    message: Query parameter value invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
                   - msgCode: 311
                     message: IO-Link parameter access error
                   - msgCode: 601
                     message: IODD is not available
                   - msgCode: 703
-                    message: Incompatible data set combination, the whole data set is rejected
+                    message: Data set combination is incompatible
         '403':
           description: Forbidden
           content:
@@ -3447,7 +3438,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -3460,7 +3451,7 @@ paths:
                   - msgCode: 304
                     message: deviceName not found
                   - msgCode: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
                   - msgCode: 309
                     message: IO-Link parameter not found
                   - msgCode: 312
@@ -3490,7 +3481,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/deviceBlockParameterizationPost' 
+              $ref: '#/components/schemas/deviceBlockParameterizationPost'
             examples:
               read, format=byteArray:
                 value: {
@@ -3638,25 +3629,25 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 104
-                    message: Action locked by another client (e.g. fieldbus controller)
+                    message: Action locked by another client
                   - msgCode: 201
-                    message: Parsing failed (error while parsing the incoming JSON value)
+                    message: Parsing failed
                   - msgCode: 202
-                    message: Invalid data (given for the value, e.g. malformed IP address)
+                    message: Data value invalid
                   - msgCode: 203
-                    message: Invalid JSON data type (e.g. string instead of numbers)
+                    message: Data type invalid
                   - msgCode: 204
-                    message: Unknown enumeration value
+                    message: Data value enumeration unknown
                   - msgCode: 205
-                    message: Value out of range (exceeds the minimum or maximum value)
+                    message: Data value out of range
                   - msgCode: 206
-                    message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                    message: Data value out of bounds
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 306
-                    message: Incorrect query parameter value
+                    message: Query parameter value invalid
                   - msgCode: 307
-                    message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                    message: Port is not configured for IO-Link
                   - msgCode: 311
                     message: IO-Link parameter access error
                   - msgCode: 601
@@ -3664,7 +3655,7 @@ paths:
                   - msgCode: 701
                     message: Incomplete data set
                   - msgCode: 703
-                    message: Incompatible data set combination, the whole data set is rejected
+                    message: Data set combination is incompatible
         '403':
           description: Forbidden
           content:
@@ -3673,7 +3664,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -3686,7 +3677,7 @@ paths:
                   - msgCode: 304
                     message: deviceName not found
                   - msgCode: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
                   - msgCode: 309
                     message: IO-Link parameter not found
         '500':
@@ -3727,9 +3718,9 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 305
-                    message: Incorrect query parameter name
+                    message: Query parameter name invalid
                   - msgCode: 306
-                    message: Incorrect query parameter value
+                    message: Query parameter value invalid
         '403':
           description: Forbidden
           content:
@@ -3738,7 +3729,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - msgCode: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -4963,3 +4954,4 @@ components:
                 type: string
               iolError:
                 type: integer
+

--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -409,31 +409,31 @@ paths:
                 202:
                       value:
                         code: 202
-                        message: Invalid data (given for the value, e.g. malformed IP address)
+                        message: Data value invalid
                 203:
                       value:
                         code: 203
-                        message: Invalid JSON data type (e.g. string instead of numbers)
+                        message: Data type invalid
                 204:
                       value:
                         code: 204
-                        message: Unknown enumeration value
+                        message: Enumeration value unknown
                 205:
                       value:
                         code: 205
-                        message: Value out of range (exceeds the minimum or maximum value)
+                        message: Data value out of range
                 206:
                       value:
                         code: 206
-                        message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                        message: Data value out of bounds
                 305:
                       value:
                         code: 305
-                        message: Incorrect query parameter name
+                        message: Query parameter name invalid
                 701:
                       value:
                         code: 701
-                        message: Incomplete data set
+                        message: Data set incomplete
 
         '403':
           description: Forbidden

--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -43,13 +43,13 @@ info:
       - Remark: An array/string was accessed exceeding its maximum length
 
     * [207] HTTP Status 400: deviceAlias is not unique
-    
+
     * [208] HTTP Status 400: POST request without content
 
     ### Resource access errors
 
     * [301] HTTP Status 404: Resource not found
-      - Remark: wrong URL
+      - Remark: e.g. wrong URL
 
     * [302] HTTP Status 404: masterNumber not found
 
@@ -61,7 +61,7 @@ info:
 
     * [306] HTTP Status 400: Query parameter value invalid
 
-    * [307] HTTP Status 400: Port is not configured for IO-Link
+    * [307] HTTP Status 400: Port is not configured to IO-Link
       - Remark: e.g. not in IOLINK_MANUAL or IOLINK_AUTOSTART mode
 
     * [308] HTTP Status 404: IO-Link Device is not accessible
@@ -75,7 +75,7 @@ info:
       - Remark: The additional iolinkErrorCode and iolinkErrorMessage fields contain
       the IO-Link error code and the incident text from the ErrorTypes table
 
-    * [312] HTTP Status 404: IO-Link parameter name is not unique.
+    * [312] HTTP Status 404: IO-Link parameter name is not unique
       - Remark: Please use the {name}_{index} format
 
     ### Data Storage errors
@@ -196,7 +196,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -241,7 +241,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -269,11 +269,11 @@ paths:
                 Manual:
                   value:
                     ethIpv4: [
-                      { 
+                      {
                         ipConfiguration: MANUAL,
                         ipAddress: 192.168.1.13,
                         subnetMask: 255.255.255.0,
-                        standardGateway: 192.168.1.1   
+                        standardGateway: 192.168.1.1
                       }
                     ]
                 DHCP:
@@ -283,7 +283,7 @@ paths:
                         ipConfiguration: DHCP,
                         ipAddress: 192.168.100.5,
                         subnetMask: 255.255.255.0,
-                        standardGateway: 192.168.100.1  
+                        standardGateway: 192.168.100.1
                       }
                     ]
                 Multiple ethernet interfaces:
@@ -293,19 +293,19 @@ paths:
                         ipConfiguration: MANUAL,
                         ipAddress: 192.168.1.13,
                         subnetMask: 255.255.255.0,
-                        standardGateway: 192.168.1.1   
+                        standardGateway: 192.168.1.1
                       },
                       {
                         ipConfiguration: MANUAL,
                         ipAddress: 192.168.2.10,
                         subnetMask: 255.255.255.0,
-                        standardGateway: 192.168.2.1  
+                        standardGateway: 192.168.2.1
                       },
                       {
                         ipConfiguration: DHCP,
                         ipAddress: 192.168.200.7,
                         subnetMask: 255.255.255.0,
-                        standardGateway: 192.168.200.1  
+                        standardGateway: 192.168.200.1
                       }
                     ]
         '400':
@@ -329,7 +329,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -355,11 +355,11 @@ paths:
               Manual:
                 value:
                   ethIpv4: [
-                    { 
+                    {
                       ipConfiguration: MANUAL,
                       ipAddress: 192.168.1.13,
                       subnetMask: 255.255.255.0,
-                      standardGateway: 192.168.1.1   
+                      standardGateway: 192.168.1.1
                     }
                   ]
               DHCP:
@@ -376,13 +376,13 @@ paths:
                       ipConfiguration: MANUAL,
                       ipAddress: 192.168.1.13,
                       subnetMask: 255.255.255.0,
-                      standardGateway: 192.168.1.1   
+                      standardGateway: 192.168.1.1
                     },
                     {
                       ipConfiguration: MANUAL,
                       ipAddress: 192.168.2.10,
                       subnetMask: 255.255.255.0,
-                      standardGateway: 192.168.2.1  
+                      standardGateway: 192.168.2.1
                     },
                     {
                       ipConfiguration: DHCP
@@ -399,13 +399,13 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               examples:
                 104:
-                  value: 
+                  value:
                     code: 104
-                    message: Action locked by another client (e.g. fieldbuscontroller)
+                    message: Action locked by another client
                 201:
                   value:
                     code: 201
-                    message: Parsing failed (error while parsing the incoming JSON value)
+                    message: Parsing failed
 
         '403':
           description: Forbidden
@@ -417,7 +417,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -447,7 +447,7 @@ paths:
                 104:
                   value:
                     code: 104
-                    message: Action locked by another client (e.g. fieldbuscontroller)
+                    message: Action locked by another client
                 305:
                   value:
                     code: 305
@@ -462,7 +462,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -492,7 +492,7 @@ paths:
                 104:
                   value:
                     code: 104
-                    message: Action locked by another client (e.g. fieldbuscontroller)
+                    message: Action locked by another client
                 305:
                   value:
                     code: 305
@@ -507,7 +507,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -686,7 +686,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -751,7 +751,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -815,23 +815,23 @@ paths:
                 $ref: '#/components/schemas/errorObject'
               example:
                 - code: 104
-                  message: Action locked by another client (e.g. fieldbus controller)
+                  message: Action locked by another client
                 - code: 201
-                  message: Parsing failed (error while parsing the incoming JSON value)
+                  message: Parsing failed
                 - code: 202
-                  message: Invalid data (given for the value, e.g. malformed IP address)
+                  message: Data value invalid
                 - code: 203
-                  message: Invalid JSON data type (e.g. string instead of numbers)
+                  message: Data type invalid
                 - code: 204
-                  message: Unknown enumeration value
+                  message: Enumeration value unknown
                 - code: 205
-                  message: Value out of range (exceeds the minimum or maximum value)
+                  message: Data value out of range
                 - code: 206
-                  message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                  message: Data value out of bounds
                 - code: 305
                   message: Incorrect query parameter name
                 - code: 701
-                  message: Incomplete data set
+                  message: Data set incomplete
         '403':
           description: Forbidden
           content:
@@ -842,7 +842,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -924,7 +924,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1000,27 +1000,27 @@ paths:
                 201:
                   value:
                     code: 201
-                    message: Parsing failed (error while parsing the incoming JSON value)
+                    message: Parsing failed
                 202:
                   value:
                     code: 202
-                    message: Invalid data (given for the value, e.g. malformed IP address)
+                    message: Data value invalid
                 203:
                   value:
                     code: 203
-                    message: Invalid JSON data type (e.g. string instead of numbers)
+                    message: Data type invalid
                 204:
                   value:
                     code: 204
-                    message: Unknown enumeration value
+                    message: Enumeration value unknown
                 205:
                   value:
                     code: 205
-                    message: Value out of range (exceeds the minimum or maximum value)
+                    message: Data value out of range
                 206:
                   value:
                     code: 206
-                    message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                    message: Data value out of bounds
                 305:
                   value:
                     code: 305
@@ -1028,7 +1028,7 @@ paths:
                 701:
                   value:
                     code: 701
-                    message: Incomplete data set
+                    message: Data set incomplete
         '403':
           description: Forbidden
           content:
@@ -1039,7 +1039,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1121,7 +1121,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1136,7 +1136,7 @@ paths:
                 301:
                   value:
                     code: 301
-                    message: Resource not found (e.g. wrong URL)
+                    message: Resource not found
         '500':
           description: Internal server error
           content:
@@ -1182,7 +1182,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1197,7 +1197,7 @@ paths:
                 301:
                   value:
                     code: 301
-                    message: Resource not found (e.g. wrong URL)
+                    message: Resource not found
         '500':
           description: Internal server error
           content:
@@ -1247,7 +1247,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1306,15 +1306,15 @@ paths:
                 603:
                   value:
                     code: 603
-                    message: Uploaded file is no valid IODD XML. Upload rejected
+                    message: IODD upload failed. IODD XML invalid
                 604:
                   value:
                     code: 604
-                    message: Uploaded file is no valid IODD XML. CRC check failed
+                    message: IODD upload failed. CRC error
                 605:
                   value:
                     code: 605
-                    message: Uploaded file is no valid IODD XML. Parsing failed
+                    message: IODD upload failed. Parsing error
         '403':
           description: Forbidden
           content:
@@ -1325,7 +1325,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1351,7 +1351,7 @@ paths:
                 602:
                   value:
                     code: 602
-                    message: Unable to upload IODD XML file. Insufficient memory space
+                    message: IODD upload failed. Not enough memory
   '/iodds/vendors/{vendorId}/devices/{deviceId}/revisions/{ioLinkRevision}':
     get:
       tags:
@@ -1392,7 +1392,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1407,7 +1407,7 @@ paths:
                 301:
                   value:
                     code: 301
-                    message: Resource not found (e.g. wrong URL)
+                    message: Resource not found
         '500':
           description: Internal server error
           content:
@@ -1455,7 +1455,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1470,7 +1470,7 @@ paths:
                 301:
                   value:
                     code: 301
-                    message: Resource not found (e.g. wrong URL)
+                    message: Resource not found
         '500':
           description: Internal server error
           content:
@@ -1517,7 +1517,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -1567,7 +1567,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Bad request
           content:
@@ -1626,23 +1626,23 @@ paths:
                 104:
                   value:
                     code: 104
-                    message: Action locked by another client (e.g. fieldbus controller)
+                    message: Action locked by another client
                 201:
                   value:
                     code: 201
-                    message: Parsing failed (error while parsing the incoming JSON value)
+                    message: Parsing failed
                 202:
                   value:
                     code: 202
-                    message: Invalid data (given for the value, e.g. malformed IP address)
+                    message: Data value invalid
                 203:
                   value:
                     code: 203
-                    message: Invalid JSON data type (e.g. string instead of numbers)
+                    message: Data type invalid
                 206:
                   value:
                     code: 206
-                    message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                    message: Data value out of bounds
                 305:
                   value:
                     code: 305
@@ -1657,7 +1657,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1719,7 +1719,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1794,7 +1794,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1857,7 +1857,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1924,7 +1924,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -1995,31 +1995,31 @@ paths:
                 104:
                   value:
                     code: 104
-                    message: Action locked by another client (e.g. fieldbus controller)
+                    message: Action locked by another client
                 201:
                   value:
                     code: 201
-                    message: Parsing failed (error while parsing the incoming JSON value)
+                    message: Parsing failed
                 202:
                   value:
                     code: 202
-                    message: Invalid data (given for the value, e.g. malformed IP address)
+                    message: Data value invalid
                 203:
                   value:
                     code: 203
-                    message: Invalid JSON data type (e.g. string instead of numbers)
+                    message: Data type invalid
                 204:
                   value:
                     code: 204
-                    message: Unknown enumeration value
+                    message: Enumeration value unknown
                 205:
                   value:
                     code: 205
-                    message: Value out of range (exceeds the minimum or maximum value)
+                    message: Data value out of range
                 207:
                   value:
                     code: 207
-                    message: Duplicated Device Name
+                    message: deviceAlias is not unique
                 305:
                   value:
                     code: 305
@@ -2027,11 +2027,11 @@ paths:
                 702:
                   value:
                     code: 702
-                    message: Data set not applicable (not supported), the whole data set is rejected
+                    message: Data set not applicable
                 703:
                   value:
                     code: 703
-                    message: Incompatible data set combination, the whole data set is rejected
+                    message: Data set combination incompatible
         '403':
           description: Forbidden
           content:
@@ -2042,7 +2042,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2109,7 +2109,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2191,7 +2191,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2263,31 +2263,31 @@ paths:
                 104:
                   value:
                     code: 104
-                    message: Action locked by another client (e.g. fieldbus controller)
+                    message: Action locked by another client
                 201:
                   value:
                     code: 201
-                    message: Parsing failed (error while parsing the incoming JSON value)
+                    message: Parsing failed
                 202:
                   value:
                     code: 202
-                    message: Invalid data (given for the value, e.g. malformed IP address)
+                    message: Data value invalid
                 203:
                   value:
                     code: 203
-                    message: Invalid JSON data type (e.g. string instead of numbers)
+                    message: Data type invalid
                 204:
                   value:
                     code: 204
-                    message: Unknown enumeration value
+                    message: Enumeration value unknown
                 205:
                   value:
                     code: 205
-                    message: Value out of range (exceeds the minimum or maximum value)
+                    message: Data value out of range
                 206:
                   value:
                     code: 206
-                    message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                    message: Data value out of bounds
                 305:
                   value:
                     code: 305
@@ -2295,11 +2295,11 @@ paths:
                 401:
                   value:
                     msgcode: 401
-                    message: Mismatch between configured device and data storage meta data
+                    message: Data storage mismatch
                 701:
                   value:
                     code: 701
-                    message: Incomplete data set
+                    message: Data set incomplete
         '403':
           description: Forbidden
           content:
@@ -2310,7 +2310,7 @@ paths:
                 150:
                   value:
                     code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2402,7 +2402,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '500':
           description: Internal server error
           content:
@@ -2450,7 +2450,7 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
         '403':
           description: Forbidden
           content:
@@ -2461,7 +2461,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -2476,7 +2476,7 @@ paths:
                 308:
                   value:
                     code: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
         '500':
           description: Internal server error
           content:
@@ -2524,23 +2524,23 @@ paths:
                     104:
                       value:
                         code: 104
-                        message: Action locked by another client (e.g. fieldbus controller)
+                        message: Action locked by another client
                     201:
                       value:
                         code: 201
-                        message: Parsing failed (error while parsing the incoming JSON value)
+                        message: Parsing failed
                     202:
                       value:
                         code: 202
-                        message: Invalid data (given for the value, e.g. malformed IP address)
+                        message: Data value invalid
                     203:
                       value:
                         code: 203
-                        message: Invalid JSON data type (e.g. string instead of numbers)
+                        message: Data type invalid
                     206:
                       value:
                         code: 206
-                        message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                        message: Data value out of bounds
                     305:
                       value:
                         code: 305
@@ -2548,7 +2548,7 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
         '403':
           description: Forbidden
           content:
@@ -2559,7 +2559,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -2574,7 +2574,7 @@ paths:
                     308:
                       value:
                         code: 308
-                        message: IO-Link Device is not accessible (not connected or communication error)
+                        message: IO-Link Device is not accessible
                     309:
                       value:
                         code: 309
@@ -2582,7 +2582,7 @@ paths:
                     310:
                       value:
                         code: 310
-                        message: IO-Link parameter access not supported by the Device
+                        message: IO-Link parameter access not supported by the device
         '500':
           description: Internal server error
           content:
@@ -2630,7 +2630,7 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
         '404':
           description: Not found
           content:
@@ -2645,7 +2645,7 @@ paths:
                 308:
                   value:
                     code: 308
-                    message: IO-Link Device is not accessible (not connected or communication error)
+                    message: IO-Link Device is not accessible
         '500':
           description: Internal server error
           content:
@@ -2756,7 +2756,7 @@ paths:
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
         '403':
           description: Forbidden
           content:
@@ -2767,7 +2767,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -2856,31 +2856,31 @@ paths:
                     104:
                       value:
                         code: 104
-                        message: Action locked by another client (e.g. fieldbus controller)
+                        message: Action locked by another client
                     201:
                       value:
                         code: 201
-                        message: Parsing failed (error while parsing the incoming JSON value)
+                        message: Parsing failed
                     202:
                       value:
                         code: 202
-                        message: Invalid data (given for the value, e.g. malformed IP address)
+                        message: Data value invalid
                     203:
                       value:
                         code: 203
-                        message: Invalid JSON data type (e.g. string instead of numbers)
+                        message: Data type invalid
                     204:
                       value:
                         code: 204
-                        message: Unknown enumeration value
+                        message: Enumeration value unknown
                     205:
                       value:
                         code: 205
-                        message: Value out of range (exceeds the minimum or maximum value)
+                        message: Data value out of range
                     206:
                       value:
                         code: 206
-                        message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                        message: Data value out of bounds
                     305:
                       value:
                         code: 305
@@ -2892,27 +2892,27 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
                     501:
                       value:
                         code: 501
-                        message: Writing processdata to Pin 2 is not possible. Pin 2 is not configured as DIGITAL_OUTPUT
+                        message: I/Q is not configured as DIGITAL_OUTPUT
                     502:
                       value:
                         code: 502
-                        message: Writing processdata to Pin 4 is not possible. Pin 4 is not configured as DIGITAL_OUTPUT
+                        message: C/Q is not configured as DIGITAL_OUTPUT
                     503:
                       value:
                         code: 503
-                        message: Attached IO-Link device has no output process data
+                        message: IO-Link device has no output process data
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
                     703:
                       value:
                         code: 703
-                        message: Incompatible data set combination, the whole data set is rejected
+                        message: Data set combination incompatible
         '403':
           description: Forbidden
           content:
@@ -2921,7 +2921,7 @@ paths:
                   $ref: '#/components/schemas/errorObject'
                 example:
                   - code: 150
-                    message: Permission denied (e.g. user management)
+                    message: Permission denied
         '404':
           description: Not found
           content:
@@ -2940,7 +2940,7 @@ paths:
                     308:
                       value:
                         code: 308
-                        message: IO-Link Device is not accessible (not connected or communication error)
+                        message: IO-Link Device is not accessible
         '500':
           description: Internal server error
           content:
@@ -2986,7 +2986,7 @@ paths:
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
         '403':
           description: Forbidden
           content:
@@ -2997,7 +2997,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -3046,7 +3046,7 @@ paths:
                 $ref: '#/components/schemas/deviceParameterValueGetPost'
               examples:
                 format=byteArray:
-                  value: { 
+                  value: {
                       "value": [
                         0,
                         156,
@@ -3067,7 +3067,7 @@ paths:
                       "value": 12
                     }
                   }
-                  
+
         '400':
           description: Bad request
           content:
@@ -3086,7 +3086,7 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
                     311:
                       value:
                         code: 311
@@ -3094,7 +3094,7 @@ paths:
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
         '403':
           description: Forbidden
           content:
@@ -3105,7 +3105,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -3124,7 +3124,7 @@ paths:
                     308:
                       value:
                         code: 308
-                        message: IO-Link Device is not accessible (not connected or communication error)
+                        message: IO-Link Device is not accessible
                     309:
                       value:
                         code: 309
@@ -3159,7 +3159,7 @@ paths:
               $ref: '#/components/schemas/deviceParameterValueGetPost'
             examples:
                 format=byteArray:
-                  value: { 
+                  value: {
                       "value": [
                         0,
                         156,
@@ -3197,31 +3197,31 @@ paths:
                     104:
                       value:
                         code: 104
-                        message: Action locked by another client (e.g. fieldbus controller)
+                        message: Action locked by another client
                     201:
                       value:
                         code: 201
-                        message: Parsing failed (error while parsing the incoming JSON value)
+                        message: Parsing failed
                     202:
                       value:
                         code: 202
-                        message: Invalid data (given for the value, e.g. malformed IP address)
+                        message: Data value invalid
                     203:
                       value:
                         code: 203
-                        message: Invalid JSON data type (e.g. string instead of numbers)
+                        message: Data type invalid
                     204:
                       value:
                         code: 204
-                        message: Unknown enumeration value
+                        message: Enumeration value unknown
                     205:
                       value:
                         code: 205
-                        message: Value out of range (exceeds the minimum or maximum value)
+                        message: Data value out of range
                     206:
                       value:
                         code: 206
-                        message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                        message: Data value out of bounds
                     305:
                       value:
                         code: 305
@@ -3233,7 +3233,7 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
                     311:
                       value:
                         code: 311
@@ -3241,11 +3241,11 @@ paths:
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
                     703:
                       value:
                         code: 703
-                        message: Incompatible data set combination, the whole data set is rejected
+                        message: Data set combination incompatible
         '403':
           description: Forbidden
           content:
@@ -3256,7 +3256,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -3271,7 +3271,7 @@ paths:
                     308:
                       value:
                         code: 308
-                        message: IO-Link Device is not accessible (not connected or communication error)
+                        message: IO-Link Device is not accessible
                     309:
                       value:
                         code: 309
@@ -3348,7 +3348,7 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
                     311:
                       value:
                         code: 311
@@ -3356,7 +3356,7 @@ paths:
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
         '403':
           description: Forbidden
           content:
@@ -3367,7 +3367,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -3386,7 +3386,7 @@ paths:
                     308:
                       value:
                         code: 308
-                        message: IO-Link Device is not accessible (not connected or communication error)
+                        message: IO-Link Device is not accessible
                     309:
                       value:
                         code: 309
@@ -3459,31 +3459,31 @@ paths:
                     104:
                       value:
                         code: 104
-                        message: Action locked by another client (e.g. fieldbus controller)
+                        message: Action locked by another client
                     201:
                       value:
                         code: 201
-                        message: Parsing failed (error while parsing the incoming JSON value)
+                        message: Parsing failed
                     202:
                       value:
                         code: 202
-                        message: Invalid data (given for the value, e.g. malformed IP address)
+                        message: Data value invalid
                     203:
                       value:
                         code: 203
-                        message: Invalid JSON data type (e.g. string instead of numbers)
+                        message: Data type invalid
                     204:
                       value:
                         code: 204
-                        message: Unknown enumeration value
+                        message: Enumeration value unknown
                     205:
                       value:
                         code: 205
-                        message: Value out of range (exceeds the minimum or maximum value)
+                        message: Data value out of range
                     206:
                       value:
                         code: 206
-                        message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                        message: Data value out of bounds
                     305:
                       value:
                         code: 305
@@ -3495,7 +3495,7 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
                     311:
                       value:
                         code: 311
@@ -3503,11 +3503,11 @@ paths:
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
                     703:
                       value:
                         code: 703
-                        message: Incompatible data set combination, the whole data set is rejected
+                        message: Data set combination incompatible
         '403':
           description: Forbidden
           content:
@@ -3518,7 +3518,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -3537,7 +3537,7 @@ paths:
                     308:
                       value:
                         code: 308
-                        message: IO-Link Device is not accessible (not connected or communication error)
+                        message: IO-Link Device is not accessible
                     309:
                       value:
                         code: 309
@@ -3592,7 +3592,7 @@ paths:
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
         '403':
           description: Forbidden
           content:
@@ -3603,7 +3603,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -3669,7 +3669,7 @@ paths:
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
         '403':
           description: Forbidden
           content:
@@ -3680,7 +3680,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -3739,7 +3739,7 @@ paths:
                 $ref: '#/components/schemas/deviceParameterSubindexValueGetPost'
               examples:
                 format=byteArray:
-                  value: { 
+                  value: {
                       "value": [
                         0,
                         156,
@@ -3769,7 +3769,7 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
                     311:
                       value:
                         code: 311
@@ -3777,7 +3777,7 @@ paths:
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
         '403':
           description: Forbidden
           content:
@@ -3788,7 +3788,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -3807,7 +3807,7 @@ paths:
                     308:
                       value:
                         code: 308
-                        message: IO-Link Device is not accessible (not connected or communication error)
+                        message: IO-Link Device is not accessible
                     309:
                       value:
                         code: 309
@@ -3844,7 +3844,7 @@ paths:
               $ref: '#/components/schemas/deviceParameterSubindexValueGetPost'
             examples:
                 format=byteArray:
-                  value: { 
+                  value: {
                       "value": [
                         0,
                         156,
@@ -3869,31 +3869,31 @@ paths:
                     104:
                       value:
                         code: 104
-                        message: Action locked by another client (e.g. fieldbus controller)
+                        message: Action locked by another client
                     201:
                       value:
                         code: 201
-                        message: Parsing failed (error while parsing the incoming JSON value)
+                        message: Parsing failed
                     202:
                       value:
                         code: 202
-                        message: Invalid data (given for the value, e.g. malformed IP address)
+                        message: Data value invalid
                     203:
                       value:
                         code: 203
-                        message: Invalid JSON data type (e.g. string instead of numbers)
+                        message: Data type invalid
                     204:
                       value:
                         code: 204
-                        message: Unknown enumeration value
+                        message: Enumeration value unknown
                     205:
                       value:
                         code: 205
-                        message: Value out of range (exceeds the minimum or maximum value)
+                        message: Data value out of range
                     206:
                       value:
                         code: 206
-                        message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                        message: Data value out of bounds
                     305:
                       value:
                         code: 305
@@ -3905,7 +3905,7 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
                     311:
                       value:
                         code: 311
@@ -3917,7 +3917,7 @@ paths:
                     703:
                       value:
                         code: 703
-                        message: Incompatible data set combination, the whole data set is rejected
+                        message: Data set combination incompatible
         '403':
           description: Forbidden
           content:
@@ -3928,7 +3928,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -3947,7 +3947,7 @@ paths:
                     308:
                       value:
                         code: 308
-                        message: IO-Link Device is not accessible (not connected or communication error)
+                        message: IO-Link Device is not accessible
                     309:
                       value:
                         code: 309
@@ -4016,7 +4016,7 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
                     311:
                       value:
                         code: 311
@@ -4024,7 +4024,7 @@ paths:
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
         '403':
           description: Forbidden
           content:
@@ -4035,7 +4035,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -4054,7 +4054,7 @@ paths:
                     308:
                       value:
                         code: 308
-                        message: IO-Link Device is not accessible (not connected or communication error)
+                        message: IO-Link Device is not accessible
                     309:
                       value:
                         code: 309
@@ -4122,31 +4122,31 @@ paths:
                     104:
                       value:
                         code: 104
-                        message: Action locked by another client (e.g. fieldbus controller)
+                        message: Action locked by another client
                     201:
                       value:
                         code: 201
-                        message: Parsing failed (error while parsing the incoming JSON value)
+                        message: Parsing failed
                     202:
                       value:
                         code: 202
-                        message: Invalid data (given for the value, e.g. malformed IP address)
+                        message: Data value invalid
                     203:
                       value:
                         code: 203
-                        message: Invalid JSON data type (e.g. string instead of numbers)
+                        message: Data type invalid
                     204:
                       value:
                         code: 204
-                        message: Unknown enumeration value
+                        message: Enumeration value unknown
                     205:
                       value:
                         code: 205
-                        message: Value out of range (exceeds the minimum or maximum value)
+                        message: Data value out of range
                     206:
                       value:
                         code: 206
-                        message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                        message: Data value out of bounds
                     305:
                       value:
                         code: 305
@@ -4158,7 +4158,7 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
                     311:
                       value:
                         code: 311
@@ -4166,11 +4166,11 @@ paths:
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
                     703:
                       value:
                         code: 703
-                        message: Incompatible data set combination, the whole data set is rejected
+                        message: Data set combination incompatible
         '403':
           description: Forbidden
           content:
@@ -4181,7 +4181,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -4200,7 +4200,7 @@ paths:
                     308:
                       value:
                         code: 308
-                        message: IO-Link Device is not accessible (not connected or communication error)
+                        message: IO-Link Device is not accessible
                     309:
                       value:
                         code: 309
@@ -4238,7 +4238,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/deviceBlockParameterizationPost' 
+              $ref: '#/components/schemas/deviceBlockParameterizationPost'
             examples:
               read, format=byteArray:
                 value: {
@@ -4491,31 +4491,31 @@ paths:
                     104:
                       value:
                         code: 104
-                        message: Action locked by another client (e.g. fieldbus controller)
+                        message: Action locked by another client
                     201:
                       value:
                         code: 201
-                        message: Parsing failed (error while parsing the incoming JSON value)
+                        message: Parsing failed
                     202:
                       value:
                         code: 202
-                        message: Invalid data (given for the value, e.g. malformed IP address)
+                        message: Data value invalid
                     203:
                       value:
                         code: 203
-                        message: Invalid JSON data type (e.g. string instead of numbers)
+                        message: Data type invalid
                     204:
                       value:
                         code: 204
-                        message: Unknown enumeration value
+                        message: Enumeration value unknown
                     205:
                       value:
                         code: 205
-                        message: Value out of range (exceeds the minimum or maximum value)
+                        message: Data value out of range
                     206:
                       value:
                         code: 206
-                        message: Out of bounds (an array/string was accessed exceeding its maximum length)
+                        message: Data value out of bounds
                     305:
                       value:
                         code: 305
@@ -4527,7 +4527,7 @@ paths:
                     307:
                       value:
                         code: 307
-                        message: Port is not configured in IOLINK_MANUAL or IOLINK_AUTOSTART mode
+                        message: Port is not configured to IO-Link
                     311:
                       value:
                         code: 311
@@ -4535,15 +4535,15 @@ paths:
                     601:
                       value:
                         code: 601
-                        message: IODD is not available
+                        message: IODD (representation) for this IO-Link device is not available
                     701:
                       value:
                         code: 701
-                        message: Incomplete data set
+                        message: Data set incomplete
                     703:
                       value:
                         code: 703
-                        message: Incompatible data set combination, the whole data set is rejected
+                        message: Data set combination incompatible
         '403':
           description: Forbidden
           content:
@@ -4554,7 +4554,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:
@@ -4573,7 +4573,7 @@ paths:
                     308:
                       value:
                         code: 308
-                        message: IO-Link Device is not accessible (not connected or communication error)
+                        message: IO-Link Device is not accessible
                     309:
                       value:
                         code: 309
@@ -4637,7 +4637,7 @@ paths:
                     150:
                       value:
                         code: 150
-                        message: Permission denied (e.g. user management)
+                        message: Permission denied
         '404':
           description: Not found
           content:

--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -25,21 +25,21 @@ info:
 
     ### JSON Parsing errors
 
-    * [201] HTTP Status 400: Parsing failed
+    * [201] HTTP Status 400: JSON parsing failed
       - Remark: Error while parsing the incoming JSON object
 
-    * [202] HTTP Status 400: Data value invalid
+    * [202] HTTP Status 400: JSON data value invalid
       - Remark: Error while parsing a specific JSON value, e.g. malformed IP address
 
-    * [203] HTTP Status 400: Data type invalid
+    * [203] HTTP Status 400: JSON data type invalid
       - Remark: e.g. string instead of number
 
     * [204] HTTP Status 400: Enumeration value unknown
 
-    * [205] HTTP Status 400: Data value out of range
+    * [205] HTTP Status 400: JSON data value out of range
       - Remark: Exceeds the minimum or maximum value
 
-    * [206] HTTP Status 400: Data value out of bounds
+    * [206] HTTP Status 400: JSON data value out of bounds
       - Remark: An array/string was accessed exceeding its maximum length
 
     * [207] HTTP Status 400: deviceAlias is not unique
@@ -405,15 +405,15 @@ paths:
                 201:
                   value:
                     code: 201
-                    message: Parsing failed
+                    message: JSON parsing failed
                 202:
                       value:
                         code: 202
-                        message: Data value invalid
+                        message: JSON data value invalid
                 203:
                       value:
                         code: 203
-                        message: Data type invalid
+                        message: JSON data type invalid
                 204:
                       value:
                         code: 204
@@ -421,11 +421,11 @@ paths:
                 205:
                       value:
                         code: 205
-                        message: Data value out of range
+                        message: JSON data value out of range
                 206:
                       value:
                         code: 206
-                        message: Data value out of bounds
+                        message: JSON data value out of bounds
                 305:
                       value:
                         code: 305
@@ -849,15 +849,15 @@ paths:
                 201:
                   value:
                     code: 201
-                  message: Parsing failed
+                  message: JSON parsing failed
                 202:
                   value:
                     code: 202
-                  message: Data value invalid
+                  message: JSON data value invalid
                 203:
                   value:
                     code: 203
-                  message: Data type invalid
+                  message: JSON data type invalid
                 204:
                   value:
                     code: 204
@@ -865,11 +865,11 @@ paths:
                 205:
                   value:
                     code: 205
-                  message: Data value out of range
+                  message: JSON data value out of range
                 206:
                   value:
                     code: 206
-                  message: Data value out of bounds
+                  message: JSON data value out of bounds
                 305:
                   value:
                     code: 305
@@ -1046,15 +1046,15 @@ paths:
                 201:
                   value:
                     code: 201
-                    message: Parsing failed
+                    message: JSON parsing failed
                 202:
                   value:
                     code: 202
-                    message: Data value invalid
+                    message: JSON data value invalid
                 203:
                   value:
                     code: 203
-                    message: Data type invalid
+                    message: JSON data type invalid
                 204:
                   value:
                     code: 204
@@ -1062,11 +1062,11 @@ paths:
                 205:
                   value:
                     code: 205
-                    message: Data value out of range
+                    message: JSON data value out of range
                 206:
                   value:
                     code: 206
-                    message: Data value out of bounds
+                    message: JSON data value out of bounds
                 305:
                   value:
                     code: 305
@@ -1676,19 +1676,19 @@ paths:
                 201:
                   value:
                     code: 201
-                    message: Parsing failed
+                    message: JSON parsing failed
                 202:
                   value:
                     code: 202
-                    message: Data value invalid
+                    message: JSON data value invalid
                 203:
                   value:
                     code: 203
-                    message: Data type invalid
+                    message: JSON data type invalid
                 206:
                   value:
                     code: 206
-                    message: Data value out of bounds
+                    message: JSON data value out of bounds
                 305:
                   value:
                     code: 305
@@ -2045,15 +2045,15 @@ paths:
                 201:
                   value:
                     code: 201
-                    message: Parsing failed
+                    message: JSON parsing failed
                 202:
                   value:
                     code: 202
-                    message: Data value invalid
+                    message: JSON data value invalid
                 203:
                   value:
                     code: 203
-                    message: Data type invalid
+                    message: JSON data type invalid
                 204:
                   value:
                     code: 204
@@ -2061,7 +2061,7 @@ paths:
                 205:
                   value:
                     code: 205
-                    message: Data value out of range
+                    message: JSON data value out of range
                 207:
                   value:
                     code: 207
@@ -2313,15 +2313,15 @@ paths:
                 201:
                   value:
                     code: 201
-                    message: Parsing failed
+                    message: JSON parsing failed
                 202:
                   value:
                     code: 202
-                    message: Data value invalid
+                    message: JSON data value invalid
                 203:
                   value:
                     code: 203
-                    message: Data type invalid
+                    message: JSON data type invalid
                 204:
                   value:
                     code: 204
@@ -2329,11 +2329,11 @@ paths:
                 205:
                   value:
                     code: 205
-                    message: Data value out of range
+                    message: JSON data value out of range
                 206:
                   value:
                     code: 206
-                    message: Data value out of bounds
+                    message: JSON data value out of bounds
                 305:
                   value:
                     code: 305
@@ -2574,19 +2574,19 @@ paths:
                     201:
                       value:
                         code: 201
-                        message: Parsing failed
+                        message: JSON parsing failed
                     202:
                       value:
                         code: 202
-                        message: Data value invalid
+                        message: JSON data value invalid
                     203:
                       value:
                         code: 203
-                        message: Data type invalid
+                        message: JSON data type invalid
                     206:
                       value:
                         code: 206
-                        message: Data value out of bounds
+                        message: JSON data value out of bounds
                     305:
                       value:
                         code: 305
@@ -2906,15 +2906,15 @@ paths:
                     201:
                       value:
                         code: 201
-                        message: Parsing failed
+                        message: JSON parsing failed
                     202:
                       value:
                         code: 202
-                        message: Data value invalid
+                        message: JSON data value invalid
                     203:
                       value:
                         code: 203
-                        message: Data type invalid
+                        message: JSON data type invalid
                     204:
                       value:
                         code: 204
@@ -2922,11 +2922,11 @@ paths:
                     205:
                       value:
                         code: 205
-                        message: Data value out of range
+                        message: JSON data value out of range
                     206:
                       value:
                         code: 206
-                        message: Data value out of bounds
+                        message: JSON data value out of bounds
                     305:
                       value:
                         code: 305
@@ -3247,15 +3247,15 @@ paths:
                     201:
                       value:
                         code: 201
-                        message: Parsing failed
+                        message: JSON parsing failed
                     202:
                       value:
                         code: 202
-                        message: Data value invalid
+                        message: JSON data value invalid
                     203:
                       value:
                         code: 203
-                        message: Data type invalid
+                        message: JSON data type invalid
                     204:
                       value:
                         code: 204
@@ -3263,11 +3263,11 @@ paths:
                     205:
                       value:
                         code: 205
-                        message: Data value out of range
+                        message: JSON data value out of range
                     206:
                       value:
                         code: 206
-                        message: Data value out of bounds
+                        message: JSON data value out of bounds
                     305:
                       value:
                         code: 305
@@ -3509,15 +3509,15 @@ paths:
                     201:
                       value:
                         code: 201
-                        message: Parsing failed
+                        message: JSON parsing failed
                     202:
                       value:
                         code: 202
-                        message: Data value invalid
+                        message: JSON data value invalid
                     203:
                       value:
                         code: 203
-                        message: Data type invalid
+                        message: JSON data type invalid
                     204:
                       value:
                         code: 204
@@ -3525,11 +3525,11 @@ paths:
                     205:
                       value:
                         code: 205
-                        message: Data value out of range
+                        message: JSON data value out of range
                     206:
                       value:
                         code: 206
-                        message: Data value out of bounds
+                        message: JSON data value out of bounds
                     305:
                       value:
                         code: 305
@@ -3919,15 +3919,15 @@ paths:
                     201:
                       value:
                         code: 201
-                        message: Parsing failed
+                        message: JSON parsing failed
                     202:
                       value:
                         code: 202
-                        message: Data value invalid
+                        message: JSON data value invalid
                     203:
                       value:
                         code: 203
-                        message: Data type invalid
+                        message: JSON data type invalid
                     204:
                       value:
                         code: 204
@@ -3935,11 +3935,11 @@ paths:
                     205:
                       value:
                         code: 205
-                        message: Data value out of range
+                        message: JSON data value out of range
                     206:
                       value:
                         code: 206
-                        message: Data value out of bounds
+                        message: JSON data value out of bounds
                     305:
                       value:
                         code: 305
@@ -4172,15 +4172,15 @@ paths:
                     201:
                       value:
                         code: 201
-                        message: Parsing failed
+                        message: JSON parsing failed
                     202:
                       value:
                         code: 202
-                        message: Data value invalid
+                        message: JSON data value invalid
                     203:
                       value:
                         code: 203
-                        message: Data type invalid
+                        message: JSON data type invalid
                     204:
                       value:
                         code: 204
@@ -4188,11 +4188,11 @@ paths:
                     205:
                       value:
                         code: 205
-                        message: Data value out of range
+                        message: JSON data value out of range
                     206:
                       value:
                         code: 206
-                        message: Data value out of bounds
+                        message: JSON data value out of bounds
                     305:
                       value:
                         code: 305
@@ -4541,15 +4541,15 @@ paths:
                     201:
                       value:
                         code: 201
-                        message: Parsing failed
+                        message: JSON parsing failed
                     202:
                       value:
                         code: 202
-                        message: Data value invalid
+                        message: JSON data value invalid
                     203:
                       value:
                         code: 203
-                        message: Data type invalid
+                        message: JSON data type invalid
                     204:
                       value:
                         code: 204
@@ -4557,11 +4557,11 @@ paths:
                     205:
                       value:
                         code: 205
-                        message: Data value out of range
+                        message: JSON data value out of range
                     206:
                       value:
                         code: 206
-                        message: Data value out of bounds
+                        message: JSON data value out of bounds
                     305:
                       value:
                         code: 305


### PR DESCRIPTION
Semantic alignment of the error message texts by naming the object (e.g. „Data value“) at the beginning, followed by the reason (e.g. „invalid“, „not accessible“ etc.). Before that, this was very mixed. Furthermore the naming of user hints and possible root cause examples („e.g. string instead of numbers“) was removed. This results in compact message strings that can be forwarded 1:1 to user dialogues without confronting the user with possibly irrelevant content in his context.

Incremented version number.
Removed trailing spaces.
Added line at end of file.