### PR TITLE
Resolving processDataValue schema problem.

### DIFF
--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -5912,28 +5912,18 @@ components:
     deviceProcessDataValuePost:
       $ref: '#/components/schemas/processDataValue'
     deviceByteArrayTypeValue:
-      type: object
-      required:
-        - value
-      properties:
-        value:
-          type: array
-          description: The value in byteArray format.
-          items:
-            type: number
-            minimum: 0
-            maximum: 255
+      type: array
+      description: The value in byteArray format.
+      items:
+        type: integer
+        minimum: 0
+        maximum: 255
     deviceSimpleTypeValue:
-      type: object
-      properties:
-        value:
-          oneOf:
-            - type: boolean
-            - type: string
-            - type: number
-          description: The value (with simple type) in iodd format.
-      required:
-        - value
+      oneOf:
+        - type: boolean
+        - type: string
+        - type: number
+      description: The value (with simple type) in iodd format.
     deviceComplexTypeValue:
       type: object
       minProperties: 1
@@ -5980,14 +5970,24 @@ components:
         - subIndex: 3
           subParameterName: Minimum_cycle_time
     deviceParameterValueGetPost:
-      oneOf:
-        - $ref: '#/components/schemas/deviceByteArrayTypeValue'
-        - $ref: '#/components/schemas/deviceSimpleTypeValue'
-        - $ref: '#/components/schemas/deviceComplexTypeValue'
+      type: object
+      properties:
+        value: 
+          oneOf:
+            - $ref: '#/components/schemas/deviceByteArrayTypeValue'
+            - $ref: '#/components/schemas/deviceSimpleTypeValue'
+            - $ref: '#/components/schemas/deviceComplexTypeValue'
+      required:
+        - value
     deviceParameterSubindexValueGetPost:
-      oneOf:
-        - $ref: '#/components/schemas/deviceByteArrayTypeValue'
-        - $ref: '#/components/schemas/deviceSimpleTypeValue'
+      type: object
+      properties:
+        value: 
+          oneOf:
+            - $ref: '#/components/schemas/deviceByteArrayTypeValue'
+            - $ref: '#/components/schemas/deviceSimpleTypeValue'
+      required:
+        - value
     deviceBlockParameterizationPost:
       type: object
       required:

--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -244,8 +244,7 @@ paths:
     get:
       tags:
         - gateway
-      summary: Read the network configuration of the Gateway.
-      description: Read the actual active configuration of the IO-Link Gateway. The Gateway may support multiple IPv4 interfaces
+      summary: Read the network configuration of the Gateway .
       responses:
         '200':
           description: Successful operation
@@ -265,6 +264,9 @@ paths:
                   value:
                     ethIpv4:
                       - ipConfiguration: DHCP
+                        ipAddress: 192.168.100.5
+                        subnetMask: 255.255.255.0
+                        standardGateway: 192.168.100.1
                 Multiple ethernet interfaces:
                   value:
                     ethIpv4:
@@ -277,6 +279,9 @@ paths:
                         subnetMask: 255.255.255.0
                         standardGateway: 192.168.2.1
                       - ipConfiguration: DHCP
+                        ipAddress: 192.168.200.7
+                        subnetMask: 255.255.255.0
+                        standardGateway: 192.168.200.1
         '403':
           description: Forbidden
           content:
@@ -415,7 +420,6 @@ paths:
       tags:
         - gateway
       summary: Reset the Gateway including all Masters. Optional.
-      description: Invoke a reset of the IO-Link Gateway. This may reset all configuration data and interrupt all communications channels. It is recommended to log this within the EventLog
       responses:
         '204':
           description: Successful operation
@@ -457,7 +461,6 @@ paths:
       tags:
         - gateway
       summary: Reboot the Gateway including all Masters. Optional.
-      description: Invoke a reboot of the IO-Link Gateway. This may reset all configuration data and interrupt all communications channels. It is recommended to log this within the EventLog
       responses:
         '204':
           description: Successful operation
@@ -499,9 +502,6 @@ paths:
       tags:
         - gateway
       summary: Read the EventLog containing all events from Gateway, Masters, Ports and Devices.
-      description: >
-        Each Gateway shall have an Event Log object containing the events of the devices, ports and 
-        the masters. The content of the Event Log can be read by getting the object “Gateway Event Log”
       parameters:
         - $ref: '#/components/parameters/eventOrigin'
         - $ref: '#/components/parameters/eventMasterNumber'
@@ -4974,8 +4974,6 @@ components:
       enum:
         - MANUAL
         - DHCP
-        - AUTO_IP
-        - DCP
     processData:
       allOf:
         - type: object


### PR DESCRIPTION
### Resolving processDataValue schema problem.

The processDataValue type's ioLink.value property definition specified with a oneOf. But the referenced types _deviceByteArrayTypeValue_ and _deviceSimpleTypeValue_ are objects, with a single property: value. 

#### processDataValue schema
    processDataValue:
      type: object
      properties:
        ioLink:
          type: object
          description: >
            Process data in IO-Link mode
          required:
            - valid
            - value
          properties:
            valid:
              type: boolean
              description: >
                Process data validity
            value:
              oneOf:
                - $ref: '#/components/schemas/deviceByteArrayTypeValue'
                - $ref: '#/components/schemas/deviceSimpleTypeValue'
                - $ref: '#/components/schemas/deviceComplexTypeValue'
              description: >
                Process data value
       ...

#### deviceByteArrayTypeValue schema

    deviceByteArrayTypeValue:
          type: object
          required:
            - value
          properties:
            value:
              type: array
              description: The value in byteArray format.
              items:
                type: number
                minimum: 0
                maximum: 255

#### Examples

The current example (from the YAML file) is not valid against the schema: 

    {
      "getData": {
        "ioLink": {
          "valid": true,
          "value": [
            12,
            22,
            216
          ]
        }
      },
      "setData": {
        "iqValue": true
      }
    }

Instead, the following example is valid:

    {
      "getData": {
        "ioLink": {
          "valid": true,
          "value": {
            "value": [
              12,
              22,
              216
            ]
          }
        }
      },
      "setData": {
        "iqValue": true
      }
    }


#### Proposed solution
Change the _deviceByteArrayTypeValue_ and _deviceSimpleTypeValue_ types to define only the object's value property and adjust the schemas, which are using these. Used by: _deviceParameterValueGetPost_ and _deviceParameterSubindexValueGetPost_. 
After the modification is applied, the specified examples in the YAML will be valid.
