### PR TITLE
Creating portStatusInfo schema and replacing usages with reference.

### DIFF
--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -244,7 +244,8 @@ paths:
     get:
       tags:
         - gateway
-      summary: Read the network configuration of the Gateway .
+      summary: Read the network configuration of the Gateway.
+      description: Read the actual active configuration of the IO-Link Gateway. The Gateway may support multiple IPv4 interfaces
       responses:
         '200':
           description: Successful operation
@@ -264,9 +265,6 @@ paths:
                   value:
                     ethIpv4:
                       - ipConfiguration: DHCP
-                        ipAddress: 192.168.100.5
-                        subnetMask: 255.255.255.0
-                        standardGateway: 192.168.100.1
                 Multiple ethernet interfaces:
                   value:
                     ethIpv4:
@@ -279,9 +277,6 @@ paths:
                         subnetMask: 255.255.255.0
                         standardGateway: 192.168.2.1
                       - ipConfiguration: DHCP
-                        ipAddress: 192.168.200.7
-                        subnetMask: 255.255.255.0
-                        standardGateway: 192.168.200.1
         '403':
           description: Forbidden
           content:
@@ -420,6 +415,7 @@ paths:
       tags:
         - gateway
       summary: Reset the Gateway including all Masters. Optional.
+      description: Invoke a reset of the IO-Link Gateway. This may reset all configuration data and interrupt all communications channels. It is recommended to log this within the EventLog
       responses:
         '204':
           description: Successful operation
@@ -461,6 +457,7 @@ paths:
       tags:
         - gateway
       summary: Reboot the Gateway including all Masters. Optional.
+      description: Invoke a reboot of the IO-Link Gateway. This may reset all configuration data and interrupt all communications channels. It is recommended to log this within the EventLog
       responses:
         '204':
           description: Successful operation
@@ -502,6 +499,9 @@ paths:
       tags:
         - gateway
       summary: Read the EventLog containing all events from Gateway, Masters, Ports and Devices.
+      description: >
+        Each Gateway shall have an Event Log object containing the events of the devices, ports and 
+        the masters. The content of the Event Log can be read by getting the object “Gateway Event Log”
       parameters:
         - $ref: '#/components/parameters/eventOrigin'
         - $ref: '#/components/parameters/eventMasterNumber'
@@ -4974,6 +4974,8 @@ components:
       enum:
         - MANUAL
         - DHCP
+        - AUTO_IP
+        - DCP
     processData:
       allOf:
         - type: object

--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -1837,7 +1837,7 @@ paths:
                       type: integer
                       minimum: 1
                     statusInfo:
-                      type: string
+                      $ref: '#/components/schemas/portStatusInfo'
                     deviceAlias:
                       type: string
                 example:
@@ -5528,22 +5528,24 @@ components:
         connectionStatus: CONNECTION_ACCEPTED
         serverAddress: 'http://broker-address.com'
         upTime: 1050
+    portStatusInfo:
+      type: string
+      enum:
+        - COMMUNICATION_LOST
+        - DEACTIVATED
+        - INCORRECT_DEVICE
+        - DEVICE_STARTING
+        - DEVICE_ONLINE
+        - DIGITAL_INPUT_C/Q
+        - DIGITAL_OUTPUT_C/Q
+        - NOT_AVAILABLE
     portStatusGet:
       type: object
       required:
         - statusInfo
       properties:
         statusInfo:
-          type: string
-          enum:
-            - COMMUNICATION_LOST
-            - DEACTIVATED
-            - INCORRECT_DEVICE
-            - DEVICE_STARTING
-            - DEVICE_ONLINE
-            - DIGITAL_INPUT_C/Q
-            - DIGITAL_OUTPUT_C/Q
-            - NOT_AVAILABLE
+          $ref: '#/components/schemas/portStatusInfo'
         ioLinkRevision:
           description: >-
             Mandatory if the portStatusInfo is INCORRECT_DEVICE, PREOPERATE or

--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -244,8 +244,7 @@ paths:
     get:
       tags:
         - gateway
-      summary: Read the network configuration of the Gateway.
-      description: Read the actual active configuration of the IO-Link Gateway. The Gateway may support multiple IPv4 interfaces
+      summary: Read the network configuration of the Gateway .
       responses:
         '200':
           description: Successful operation
@@ -265,6 +264,9 @@ paths:
                   value:
                     ethIpv4:
                       - ipConfiguration: DHCP
+                        ipAddress: 192.168.100.5
+                        subnetMask: 255.255.255.0
+                        standardGateway: 192.168.100.1
                 Multiple ethernet interfaces:
                   value:
                     ethIpv4:
@@ -277,6 +279,9 @@ paths:
                         subnetMask: 255.255.255.0
                         standardGateway: 192.168.2.1
                       - ipConfiguration: DHCP
+                        ipAddress: 192.168.200.7
+                        subnetMask: 255.255.255.0
+                        standardGateway: 192.168.200.1
         '403':
           description: Forbidden
           content:
@@ -415,7 +420,6 @@ paths:
       tags:
         - gateway
       summary: Reset the Gateway including all Masters. Optional.
-      description: Invoke a reset of the IO-Link Gateway. This may reset all configuration data and interrupt all communications channels. It is recommended to log this within the EventLog
       responses:
         '204':
           description: Successful operation
@@ -457,7 +461,6 @@ paths:
       tags:
         - gateway
       summary: Reboot the Gateway including all Masters. Optional.
-      description: Invoke a reboot of the IO-Link Gateway. This may reset all configuration data and interrupt all communications channels. It is recommended to log this within the EventLog
       responses:
         '204':
           description: Successful operation
@@ -499,9 +502,6 @@ paths:
       tags:
         - gateway
       summary: Read the EventLog containing all events from Gateway, Masters, Ports and Devices.
-      description: >
-        Each Gateway shall have an Event Log object containing the events of the devices, ports and 
-        the masters. The content of the Event Log can be read by getting the object “Gateway Event Log”
       parameters:
         - $ref: '#/components/parameters/eventOrigin'
         - $ref: '#/components/parameters/eventMasterNumber'
@@ -4974,8 +4974,6 @@ components:
       enum:
         - MANUAL
         - DHCP
-        - AUTO_IP
-        - DCP
     processData:
       allOf:
         - type: object


### PR DESCRIPTION
### Creating portStatusInfo schema and replacing usages with reference.
Port status is indicated in the requests:

- GET _/masters/{masterNumber}/ports_
- GET _/masters/{masterNumber}/ports/{portNumber}/status_

Schema portStatusGet, used by the _/masters/{masterNumber}/ports/{portNumber}/status_ endpoint defines an enum for the allowed statuses.

    statusInfo:
      type: string
      enum:
        - COMMUNICATION_LOST
        - DEACTIVATED
        - INCORRECT_DEVICE
        - DEVICE_STARTING
        - DEVICE_ONLINE
        - DIGITAL_INPUT_C/Q
        - DIGITAL_OUTPUT_C/Q
        - NOT_AVAILABLE

In _/masters/{masterNumber}/ports_ statusInfo specified as:

    statusInfo:
      type: string

#### Proposed solution

Enumeration is placed into a separate schema and referenced in both response body descriptions.