### PR TITLE
Unused response schema: errorResponse removed.

### DIFF
--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -6208,20 +6208,3 @@ components:
       schema:
         type: string
       required: true
-  responses:
-    errorResponse:
-      description: Error
-      content:
-        application/json:
-          schema:
-            type: object
-            required:
-              - code
-              - message
-            properties:
-              code:
-                type: integer
-              message:
-                type: string
-              iolError:
-                type: integer


### PR DESCRIPTION
### Unused response schema: errorResponse removed.

The errorResponse response schema is not used in the specification.