### PR TITLE
Creating iqConfigurationType schema and replacing usages with reference.

### DIFF
--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -5689,6 +5689,13 @@ components:
           value: 0.3
           unit: A
         portType: CLASS_A
+    iqConfigurationType:
+      type: string
+      enum:
+        - NOT_SUPPORTED
+        - DIGITAL_INPUT
+        - DIGITAL_OUTPUT
+        - POWER_2
     portConfigurationGet:
       type: object
       required:
@@ -5736,17 +5743,13 @@ components:
           minimum: 1
           maximum: 16777215
         iqConfiguration:
-          type: string
-          enum:
-            - NOT_SUPPORTED
-            - DIGITAL_INPUT
-            - DIGITAL_OUTPUT
+          $ref : '#/components/schemas/iqConfigurationType'
         deviceAlias:
           type: string
       example:
         mode: IOLINK_MANUAL
         validationAndBackup: TYPE_COMPATIBLE_DEVICE_V1.1
-        iqConfiguration: ANALOG_INPUT
+        iqConfiguration: DIGITAL_INPUT
         cycleTime:
           value: 2.3
           unit: ms
@@ -5798,14 +5801,7 @@ components:
           minimum: 1
           maximum: 16777215
         iqConfiguration:
-          type: string
-          enum:
-            - NOT_SUPPORTED
-            - DIGITAL_INPUT
-            - DIGITAL_OUTPUT
-            - ANALOG_INPUT
-            - ANALOG_OUTPUT
-            - POWER_2
+          $ref : '#/components/schemas/iqConfigurationType'
         deviceAlias:
           type: string
     dataStorageGetPost:


### PR DESCRIPTION
### Resolving multiple IQ configuration enumerations.

Different enumerations are defined for the GET and the POST _/masters/{masterNumber}/ports/{portNumber}/configuration_ request. 

GET:

    iqConfiguration:
      type: string
      enum:
        - NOT_SUPPORTED
        - DIGITAL_INPUT
        - DIGITAL_OUTPUT

POST:

    iqConfiguration:
      type: string
      enum:
        - NOT_SUPPORTED
        - DIGITAL_INPUT
        - DIGITAL_OUTPUT
        - ANALOG_INPUT
        - ANALOG_OUTPUT
        - POWER_2

ANALOG_INPUT and ANALOG_OUTPUT are outdated. 
Allowed IQ behavior (Table E.3) values according to the V113 Interface specification:

    0: No Device check
    1: Type compatible Device V1.0
    2: Type compatible Device V1.1
    3: Type compatible Device V1.1,Backup + Restore
    4: Type compatible Device V1.1,Restore
    5 to 255: Reserved

After removing ANALOG_INPUT and ANALOG_OUTPUT from the POST iqConfiguration enum, the allowed values are matching with the SMI ones.

#### Proposed solution

Defining IQ configuration enum separately and using it as a reference when required. Thus GET and POST enumeration values will be the same.

ANALOG_INPUT in example changed.