### PR TITLE
parameterChecksum property correction.

### DIFF
--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -5009,8 +5009,10 @@ components:
                   enum:
                     - '1.0'
                     - '1.1'
-                parameterChecks:
+                parameterChecksum:
                   type: integer
+                  minimum: 0
+                  maximum: 4294967296
             - type: object # empty object
               additionalProperties: false
               minProperties: 0


### PR DESCRIPTION
Correction in the DataStorage header property: parameterChecksum.
Value restrictions are added according to V113 Interface Spec. Jun19, Table G.2.