### PR TITLE
Remove capital "L" of iolinkRevsion property name

### DIFF
--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -1030,7 +1030,7 @@ paths:
         Get a list of all IODD (representations) that are available on the Gateway.
       description: >-
         Only one version of an IODD is stored on the webserver at the same time
-        for one vendorId-deviceId-ioLinkRevision-combination.
+        for one vendorId-deviceId-iolinkRevision-combination.
       parameters:
         - $ref: "#/components/parameters/vendorId"
         - $ref: "#/components/parameters/deviceId"
@@ -1797,7 +1797,7 @@ paths:
                 IO-Link:
                   value:
                     statusInfo: "DEVICE_ONLINE"
-                    ioLinkRevision: "1.1"
+                    iolinkRevision: "1.1"
                     transmissionRate: COM2
                     masterCycleTime:
                       value: 2.3
@@ -1808,7 +1808,7 @@ paths:
                     portQualityInfo:
                       pdInValid: true
                       pdOutValid: true
-                    ioLinkRevision: "1.1"
+                    iolinkRevision: "1.1"
                     inputDataLength: 2
                     outputDataLength: 2
                     vendorId: 888
@@ -1973,7 +1973,7 @@ paths:
                     header:
                       vendorId: 15
                       deviceId: 65253
-                      ioLinkRevision: "1.1"
+                      iolinkRevision: "1.1"
                       parameterChecksum: 123456
                     content: >-
                       TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGl
@@ -2008,7 +2008,7 @@ paths:
                   header:
                     vendorId: 15
                     deviceId: 65253
-                    ioLinkRevision: "1.1"
+                    iolinkRevision: "1.1"
                   content: >-
                     TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGl
               Empty Data Storage:
@@ -3772,7 +3772,7 @@ components:
       required:
         - vendorId
         - deviceId
-        - ioLinkRevision
+        - iolinkRevision
         - vendorName
         - productName
       type: object
@@ -3785,7 +3785,7 @@ components:
           type: integer
           minimum: 1
           maximum: 16777215
-        ioLinkRevision:
+        iolinkRevision:
           type: string
           enum:
             - "1.0"
@@ -3841,7 +3841,7 @@ components:
       example:
         vendorId: 26
         deviceId: 8389226
-        ioLinkRevision: "1.1"
+        iolinkRevision: "1.1"
         vendorName: SICK AG
         vendorText: Sensor Intelligence.
         productName: SLG-2
@@ -4423,7 +4423,7 @@ components:
               type: string
               minLength: 26
               maxLength: 26
-            ioLinkRevision:
+            iolinkRevision:
               type: string
               enum:
                 - "1.1"
@@ -4434,11 +4434,11 @@ components:
         scanResults:
           - slotType: SSLOT
             uniqueId: 03:78:00:00:01:32:50:60:46
-            ioLinkRevision: "1.1"
+            iolinkRevision: "1.1"
             lastSeen: "2022-12-01T08:42:23.314Z"
           - slotType: DSLOT
             uniqueId: 03:78:00:00:01:32:50:60:47
-            ioLinkRevision: "1.1"
+            iolinkRevision: "1.1"
             lastSeen: "2022-12-01T09:42:23.314Z"
 
     mastersScanPost: # TODO: IOLW
@@ -4529,7 +4529,7 @@ components:
             - NOT_AVAILABLE # NOT_AVAILABLE
             - PORT_POWER_OFF # PORT_POWER_OFF
             - PAIRING_FAULT # PAIRING_TIMEOUT, PAIRING_WRONG_SLOTTYPE
-        ioLinkRevision:
+        iolinkRevision:
           description: >-
             Mandatory if the portStatusInfo is INCORRECT_DEVICE, PREOPERATE or
             OPERATE.
@@ -4896,7 +4896,7 @@ components:
               required:
                 - vendorId
                 - deviceId
-                - ioLinkRevision
+                - iolinkRevision
               properties:
                 vendorId:
                   type: integer
@@ -4906,7 +4906,7 @@ components:
                   type: integer
                   minimum: 1
                   maximum: 16777215
-                ioLinkRevision:
+                iolinkRevision:
                   type: string
                   enum:
                     - "1.0"
@@ -5116,7 +5116,7 @@ components:
         - deviceId
         - version
         - releaseDate
-        - ioLinkRevision
+        - iolinkRevision
       properties:
         vendorId:
           type: number
@@ -5126,7 +5126,7 @@ components:
           type: string
         releaseDate:
           type: string
-        ioLinkRevision:
+        iolinkRevision:
           type: string
           enum:
             - "1.0"
@@ -5144,12 +5144,12 @@ components:
           deviceId: 4567
           version: "4.3"
           releaseDate: "2018-01-02"
-          ioLinkRevision: "1.1"
+          iolinkRevision: "1.1"
         - vendorId: 4321
           deviceId: 8765
           version: "2.1"
           releaseDate: "2015-01-02"
-          ioLinkRevision: "1.1"
+          iolinkRevision: "1.1"
     iolinkErrorObject:
       type: object
       required:

--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -2238,7 +2238,7 @@ paths:
                 ? "Format=byteArray, CQ in IO-Link (only input), IQ in digital output"
                 : value:
                     getData:
-                      ioLink:
+                      iolink:
                         valid: true
                         value:
                           - 12
@@ -2249,7 +2249,7 @@ paths:
                 ? "Format=iodd, CQ in IO-Link (input and output), IQ in digital input"
                 : value:
                     getData:
-                      ioLink:
+                      iolink:
                         valid: true
                         value:
                           Distance:
@@ -2259,7 +2259,7 @@ paths:
                             value: 12
                       iqValue: true
                     setData:
-                      ioLink:
+                      iolink:
                         valid: true
                         value:
                           Buzzer:
@@ -2291,7 +2291,7 @@ paths:
             examples:
               ? "format=byteArray, CQ (pin4) in IO-Link, IQ (pin2) in digital output"
               : value:
-                  ioLink:
+                  iolink:
                     valid: true
                     value:
                       - 15
@@ -2343,7 +2343,7 @@ paths:
               examples:
                 ? "Format=byteArray, CQ (pin4) in IO-Link, IQ (pin2) in digital input"
                 : value:
-                    ioLink:
+                    iolink:
                       valid: true
                       value:
                         - 12
@@ -2352,7 +2352,7 @@ paths:
                     iqValue: true
                 "Format=iodd, CQ (pin4) in IO-Link, IQ (pin2) in digital input":
                   value:
-                    ioLink:
+                    iolink:
                       valid: true
                       value:
                         Distance:
@@ -4924,7 +4924,7 @@ components:
     processDataValue:
       type: object
       properties:
-        ioLink:
+        iolink:
           description: Process data in IO-Link mode
           allOf:
             - type: object
@@ -4960,7 +4960,7 @@ components:
             (false - 0 V, true - 24 V)
       example:
         "format=byteArray, pin4=IO-Link, pin2=sio":
-          ioLink:
+          iolink:
             valid: true
             value:
               - 15
@@ -4983,7 +4983,7 @@ components:
       description: >
         The cqValue is present in the 'getData' object if the CQ (pin4) is configured as
         digital input. The cqValue is present in the 'setData' object if the CQ (pin4)
-        is configured as digital output. The ioLink is present either in the
+        is configured as digital output. The iolink is present either in the
         'getData' or 'setData' or both objects if the CQ (pin4) is configured to IO-Link mode.
         The iqValue is present in the 'getData' object if the IQ (pin2) is configured as
         digital input. The iqValue is present in the 'setData' object if the IQ (pin4)


### PR DESCRIPTION
According to the V1.0.0. specification it must be a lowercase "L" in ioLinkRevision.

![image](https://github.com/iolinkcommunity/JSON_for_IO-Link/assets/95340986/cde417a0-7303-4e2d-94a4-5dbdc10731eb)
