### PR TITLE
A device should always be accessible via the default alias.

### DIFF
--- a/JSON_for_IO-Link.yaml
+++ b/JSON_for_IO-Link.yaml
@@ -5207,9 +5207,10 @@ components:
       name: deviceAlias
       in: path
       description: >-
-        Device Name configured with the port/configuration URL. Default Device
-        Name is 'masterNportM' where 'N' means the masterNumber and 'M' means
-        the portNumber.
+        Device name configured with the port/configuration URL. Default device
+        name is 'masterNportM' where 'N' means the masterNumber and 'M' means
+        the portNumber. Even if a new device alias has been assigned, the device
+        can always be addressed via the default name. 
       schema:
         type: string
         minLength: 1


### PR DESCRIPTION
Even if a new device alias has been assigned, the device should always be accessible via the default name
(e.g. master1port2).  This is done to resolve #117.