### PR TITLE
Remove deviceAliasBase from the schemas

### DIFF
--- a/schemas.yaml
+++ b/schemas.yaml
@@ -1,20 +1,19 @@
 schemas:
   transactionId:
     description: Unique identifier for the transaction in for example as UUIDv4.
-  deviceAliasBase:
+  deviceAlias:
+      type: string
+      description:
+        Unique deviceAlias. Default device name is 'masterNportM' where 'N' means the masterNumber and 'M' means
+        the portNumber. Even if a new device alias has been assigned, the device can always be addressed via the default name.
+      minLength: 1
+      maxLength: 32
+      pattern: "^[a-zA-Z0-9_]{1,32}$"
+      example: master1port1
+  deviceAliasMqtt: # path parameter shall not contain a type according to async api spec
     description:
       Unique deviceAlias. Default device name is 'masterNportM' where 'N' means the masterNumber and 'M' means
-      the portNumber. Even if a new device alias has been assigned, the device can always be addressed via the default name.
-  deviceAlias:
-    allOf:
-      - $ref: "#/schemas/deviceAliasBase"
-      - type: string
-        minLength: 1
-        maxLength: 32
-        pattern: "^[a-zA-Z0-9_]{1,32}$"
-        example: master1port1
-  deviceAliasMqtt: # path parameter shall not contain a type according to async api spec
-    $ref: "#/schemas/deviceAliasBase"
+      the portNumber.
   portNumberMqtt: # path parameter shall not contain a type according to async api spec
     description: Port number.
   masterNumberMqtt: # path parameter shall not contain a type according to async api spec


### PR DESCRIPTION
Different rules are applied for the default value in case of JSON for IO-Link and MQTT for IO-Link. Description was incorrect for the MQTT.