### PR TITLE
Provision of OpenAPI and AsyncAPI specifications in multiple versions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # review when someone opens a pull request.
 
-- @fm-sick @vervoortb @haliCR1 @BaRu-ifm @lorandmolnar @roesekoSICKAG @OlafWestrik @wolfram-ladurner @alexkrizsan
+- @fm-sick @vervoortb @haliCR1 @BaRu-ifm @lorandmolnar @roesekoSICKAG @OlafWestrik @wolfram-ladurner @alexkrizsan @phkomma

--- a/JSON_for_IO-Link_unmerged.yaml
+++ b/JSON_for_IO-Link_unmerged.yaml
@@ -129,10 +129,10 @@ paths:
       responses:
         "200":
           description: Successful operation
-          content:            
+          content:
             application/json:
               schema:
-                type: object                
+                type: object
                 required:
                   - url
                 properties:
@@ -2387,7 +2387,7 @@ paths:
         - $ref: "#/components/parameters/masterNumber"
         - $ref: "#/components/parameters/portNumber"
       requestBody:
-        description: The configuration object for the specified port to be written.
+        description: The configuration object for the specified port to be written. The definition of duplicated deviceAlias has to be rejected.
         required: true
         content:
           application/json:

--- a/JSON_for_IO-Link_unmerged.yaml
+++ b/JSON_for_IO-Link_unmerged.yaml
@@ -89,70 +89,22 @@ paths:
   ################################################################################
   # general
   ################################################################################
-  "/openapi":
+  /apis:
     get:
       tags:
         - general
-      operationId: getOpenApiDocument
+      operationId: getApis
       summary: >-
-        Get the OpenAPI interface description of the IO-Link Master.
+        Read the list of available IO-Link-related OpenAPI and AsyncAPI specifications.
       description: >-
-        Get the OpenAPI interface description of the IO-Link Master. The general OpenAPI description should be adjusted in regards of vendor specific characteristics like used security schemas, supported endpoints or additional information.
+        Read the list of available IO-Link-related OpenAPI and AsyncAPI specifications. The OpenAPI or AsyncAPI specifications should be aligned with vendor-specific requirements such as used security schemas, supported endpoints, or additional information.
       responses:
         "200":
           description: Successful operation
           content:
-            application/text:
-              schema:
-                type: string
-              examples:
-                "url-github":
-                  value: https://github.com/iolinkcommunity/JSON_for_IO-Link/blob/1.0.0/JSON_for_IO-Link.yaml
-                "url-vendor":
-                  value: >-
-                    https://www.iolink-master-vendor.com/de/de/p/p672882
-            application/yaml:
-              example:
-                "yaml":
-                  value: >-
-                    openapi: 3.0.3
-                    info:
-                    description: >-
-                      This is a sample IO-Link Master server. You can find out more about IO-Link
-                      at [http://www.io-link.com](http://www.io-link.com)
-                      # Description
-                      * Draft for version 2.x
-                      ## Disclaimer:
-                      >The attention of adopters is directed to the possibility that compliance with or adoption of IO-Link Community specifications may require use of an invention covered by patent rights. The IO-Link Community shall not be responsible for identifying patents for which a license may be required by any IO-Link Community specification, or for conducting legal inquiries into the legal validity or scope of those patents that are brought to its attention. IO-Link Community specifications are prospective and advisory only. Prospective users are responsible for protecting themselves against liability for infringement of patents. 
-                      >The information contained in this document is subject to change without notice. The material in this document details an IO-Link Community specification in accordance with the license and notices set forth on this page. This document does not represent a commitment to implement any portion of this specification in any company's products. 
-                      >WHILE  THE  INFORMATION  IN  THIS  PUBLICATION   IS  BELIEVED  TO  BE ACCURATE, THE IO-LINK COMMUNITY MAKES NO WARRANTY OF ANY KIND, EXPRESS OR  IMPLIED,  WITH REGARD TO  THIS MATERIAL INCLUDING, BUT  NOT LIMITED  TO  ANY  WARRANTY  OF  TITLE  OR  OWNERSHIP,  IMPLIED  WARRANTY  OF MERCHANTABILITY OR  WARRANTY OF FITNESS FOR  PARTICULAR PURPOSE OR USE.  
-                      >In  no  event  shall  the IO-Link Community be liable  for  errors  contained  herein  or  for  indirect, incidental,  special,  consequential,  reliance  or  cover  damages,  including  loss  of profits, revenue, data or use, incurred by any user or any third party.   Compliance  with  this  specification  does  not  absolve  manufacturers  of IO-Link equipment,  from  the  requirements  of  safety  and regulatory agencies (TÜV, BIA, UL, CSA, etc.). 
-
-
-                      >IO-Link is a registered trademark. It may be used only by the members of the IO-Link Community and non-members who had acquired the corresponding license. For more detailed information on its use, refer to the rules of the IO-Link Community at www.io-link.com.
-                    version: 2.0.0
-                    title: Swagger IO-Link Master
-                    contact:
-                      email: info@io-link.com
-                    license:
-                      name: tbd
-                      url: 'http://www.io-link.com'
-                    ...
             application/json:
-              example:
-                "json":
-                  value:
-                    {
-                      "openapi": "3.0.3",
-                      "info": null,
-                      "description": "This is a sample IO-Link Master server. You can find out more about IO-Link at [http://www.io-link.com](http://www.io-link.com) # Description * Draft for version 2.x ## Disclaimer: >The attention of adopters is directed to the possibility that compliance with or adoption of IO-Link Community specifications may require use of an invention covered by patent rights. The IO-Link Community shall not be responsible for identifying patents for which a license may be required by any IO-Link Community specification, or for conducting legal inquiries into the legal validity or scope of those patents that are brought to its attention. IO-Link Community specifications are prospective and advisory only. Prospective users are responsible for protecting themselves against liability for infringement of patents.  >The information contained in this document is subject to change without notice. The material in this document details an IO-Link Community specification in accordance with the license and notices set forth on this page. This document does not represent a commitment to implement any portion of this specification in any company's products.  >WHILE  THE  INFORMATION  IN  THIS  PUBLICATION   IS  BELIEVED  TO  BE ACCURATE, THE IO-LINK COMMUNITY MAKES NO WARRANTY OF ANY KIND, EXPRESS OR  IMPLIED,  WITH REGARD TO  THIS MATERIAL INCLUDING, BUT  NOT LIMITED  TO  ANY  WARRANTY  OF  TITLE  OR  OWNERSHIP,  IMPLIED  WARRANTY  OF MERCHANTABILITY OR  WARRANTY OF FITNESS FOR  PARTICULAR PURPOSE OR USE.   >In  no  event  shall  the IO-Link Community be liable  for  errors  contained  herein  or  for  indirect, incidental,  special,  consequential,  reliance  or  cover  damages,  including  loss  of profits, revenue, data or use, incurred by any user or any third party.   Compliance  with  this  specification  does  not  absolve  manufacturers  of IO-Link equipment,  from  the  requirements  of  safety  and regulatory agencies (TÜV, BIA, UL, CSA, etc.). \n\n>IO-Link is a registered trademark. It may be used only by the members of the IO-Link Community and non-members who had acquired the corresponding license. For more detailed information on its use, refer to the rules of the IO-Link Community at www.io-link.com.",
-                      "version": "2.0.0",
-                      "title": "Swagger IO-Link Master",
-                      "contact": { "email": "info@io-link.com" },
-                      "license":
-                        { "name": "tbd", "url": "http://www.io-link.com" },
-                      ...: "to be continued",
-                    }
+              schema:
+                $ref: "./schemas.yaml#/schemas/apisGet"
         "401":
           $ref: "#/components/responses/HTTP_401"
         "403":
@@ -163,14 +115,85 @@ paths:
             application/json:
               schema:
                 $ref: "./schemas.yaml#/schemas/errorObject_101"
-  /apiversion:
+  /apis/{apiId}:
+    get:
+      tags:
+        - general
+      operationId: getApisApiId
+      summary: >-
+        Read a specific OpenAPI or AsyncAPI specification.
+      description: >-
+        Read a specific OpenAPI or AsyncAPI specification.
+      parameters:
+        - $ref: "#/components/parameters/apiId"
+      responses:
+        "200":
+          description: Successful operation
+          content:            
+            application/json:
+              schema:
+                type: object                
+                required:
+                  - url
+                properties:
+                  url:
+                    type: string
+                    description: The url referring to the OpenAPI or AsyncAPI specification.
+                    example: https://github.com/iolinkcommunity/JSON_for_IO-Link/blob/2.0.0/JSON_for_IO-Link.yaml
+              examples:
+                "url-github":
+                  value:
+                    "url": "https://github.com/iolinkcommunity/JSON_for_IO-Link/blob/2.0.0/JSON_for_IO-Link.yaml"
+                "url-vendor":
+                  value:
+                    "url": "https://www.iolink-master-vendor.com/de/de/p/p672882"
+            application/yaml:
+              example:
+                "yaml":
+                  value: >-
+                    openapi: 3.0.3
+                    info:
+                      description: >-
+                        This is a sample IO-Link Master server. You can find out more about IO-Link
+                        at [http://www.io-link.com](http://www.io-link.com)
+                        # Description
+                        * Version 2.0.0
+                        ## Disclaimer:
+                        >The attention of adopters is directed to the possibility that compliance with or adoption of IO-Link Community specifications may require use of an invention covered by patent rights. The IO-Link Community shall not be responsible for identifying patents for which a license may be required by any IO-Link Community specification, or for conducting legal inquiries into the legal validity or scope of those patents that are brought to its attention. IO-Link Community specifications are prospective and advisory only. Prospective users are responsible for protecting themselves against liability for infringement of patents. 
+                        >The information contained in this document is subject to change without notice. The material in this document details an IO-Link Community specification in accordance with the license and notices set forth on this page. This document does not represent a commitment to implement any portion of this specification in any company's products. 
+                        >WHILE  THE  INFORMATION  IN  THIS  PUBLICATION   IS  BELIEVED  TO  BE ACCURATE, THE IO-LINK COMMUNITY MAKES NO WARRANTY OF ANY KIND, EXPRESS OR  IMPLIED,  WITH REGARD TO  THIS MATERIAL INCLUDING, BUT  NOT LIMITED  TO  ANY  WARRANTY  OF  TITLE  OR  OWNERSHIP,  IMPLIED  WARRANTY  OF MERCHANTABILITY OR  WARRANTY OF FITNESS FOR  PARTICULAR PURPOSE OR USE.  
+                        >In  no  event  shall  the IO-Link Community be liable  for  errors  contained  herein  or  for  indirect, incidental,  special,  consequential,  reliance  or  cover  damages,  including  loss  of profits, revenue, data or use, incurred by any user or any third party.   Compliance  with  this  specification  does  not  absolve  manufacturers  of IO-Link equipment,  from  the  requirements  of  safety  and regulatory agencies (TÜV, BIA, UL, CSA, etc.). 
+
+                        >IO-Link is a registered trademark. It may be used only by the members of the IO-Link Community and non-members who had acquired the corresponding license. For more detailed information on its use, refer to the rules of the IO-Link Community at www.io-link.com.
+                      version: 2.0.0
+                        title: Swagger IO-Link Master
+                      contact:
+                        email: info@io-link.com
+                      license:
+                        name: tbd
+                        url: 'http://www.io-link.com'
+                    ...
+        "401":
+          $ref: "#/components/responses/HTTP_401"
+        "403":
+          $ref: "#/components/responses/HTTP_403"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas.yaml#/schemas/errorObject_101"
+  /apis/{apiId}/version:
     get:
       tags:
         - general
       operationId: getApiVersion
-      summary: Get the REST interface version identification.
+      summary: Read version information of a specific OpenAPI or AsyncAPI specification.
       description: >-
-        This version relates to the released version by the iolink community on github (e.g. https://github.com/iolinkcommunity/JSON_for_IO-Link/releases). It can be extended by vendor specific parts.
+        The provided version aligns with the released version by the iolink community on github (e.g. https://github.com/iolinkcommunity/JSON_for_IO-Link/releases).
+        It may be extended by vendor specific parts.
+      parameters:
+        - $ref: "#/components/parameters/apiId"
       responses:
         "200":
           description: Successful operation
@@ -183,16 +206,16 @@ paths:
                 properties:
                   version:
                     type: string
-                  additionalInfo:
+                  description:
                     type: string
               examples:
-                "mandatory":
+                "mandatory content":
                   value:
-                    version: 1.0.0
-                "optional addition":
+                    version: 2.0.0
+                "optional content":
                   value:
-                    version: 1.0.0
-                    additionalInfo: 1.2.3-feature-xyz
+                    version: 2.0.0
+                    description: 1.2.3-feature-xyz
         "401":
           $ref: "#/components/responses/HTTP_401"
         "403":
@@ -4104,6 +4127,14 @@ components:
             Maintenance: priviledged access for reading and writing all endpoints
             Specialist: more priviledged access for advanced features like firmware update
   parameters:
+    apiId:
+      name: apiId
+      description: API identifier of an OpenAPI or AsyncAPI specification.
+      required: true
+      in: path
+      schema:
+        type: string
+        pattern: "^[A-Za-z0-9._-]+$"
     artifact:
       name: artifact
       description: IO-Link IODD Artifacts

--- a/JSON_for_IO-Link_unmerged.yaml
+++ b/JSON_for_IO-Link_unmerged.yaml
@@ -4212,7 +4212,25 @@ components:
     parameterIdent:
       name: parameterIdent
       in: path
-      description: Parameter access either via index or parametername. Access via parametername requires IODD support.
+      description: |
+        Parameter name. Comes from the primary language name in the IODD but might be reformatted. \
+        Constraints for strings in keys of JSON key-value-pairs and URLs require the following conversion rules for those names: 
+
+        **Rule 1:** Names are based on the IODD XML Element Name inside variables or process data resolving the text in primary language. \
+        **Rule 2:** Only alphanumeric characters and underscores are allowed. All other characters are replaced by &quot; _ &quot;. \
+        **Rule 3:** Leading numbers shall be prefixed with &quot; _ &quot;.  \
+        **Rule 4:** If there are duplicate IO-Link names, the IO-Link index or subindex has to be accessed by appending the index number or subindex number behind the name according to the following scheme: `{name}_{index}` or `{name}_{subindex}`. \
+        **Rule 5:** Naming according the scheme `{name}_{index}` or `{name}_{subindex}` is always allowed even if names are not duplicated. \
+        **Rule 6:** The naming of ArrayT elements is `element_{subindex}`. \
+
+        **Examples:**
+        | IODD text Name | Index/subindex | Parameter name | Unique name (with index) |
+        |----------------|----------------|------|--------------------------|
+        | 0815 variable | 3452 | `_0815_variable` | `_0815_variable_3452` |
+        | Switchpoint (Q1) | 345 | `Switchpoint__Q1_` | `Switchpoint__Q1__345` |
+        | External temperature | 311 | `External_temperature_1` | `External_temperature_311` |
+        | External temperature | 1423 | `External_temperature_1` | `External_temperature_1423` |
+
       required: true
       schema:
         $ref: "./schemas.yaml#/schemas/parameterIdent"

--- a/JSON_for_IO-Link_unmerged.yaml
+++ b/JSON_for_IO-Link_unmerged.yaml
@@ -6,7 +6,7 @@ info:
 
     # Description
 
-    This is an [openapi specification](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md) for IO-Link gateways, masters and devices. 
+    This is an [OpenAPI document](https://spec.openapis.org/oas/v3.0.3.html) for IO-Link gateways, masters and devices. 
     You can find out more about IO-Link at [http://www.io-link.com](http://www.io-link.com)
 
 
@@ -14,8 +14,8 @@ info:
 
     * **Security:** The defined security schemas are just examples and can be replaced by vendor specifics. The way of restricting requests is as well in the responsibility of the vendor. It is recommended to limit access to writable endpoint. This should prevent misconfiguration and breaking running systems.
 
-    # Specifications
-          
+    # Specifications    
+
     * **JSON Integration for IO-Link V1.0.0 - Order No: 10.222**
 
     * **IO-Link Interface and System Specification V1.1.4 - Order No: 10.002**
@@ -45,11 +45,78 @@ info:
 
     ---
 
+    # General remarks
+
+    ## Data type conversion 
+
+    The following conversion rules shall be applied for the data type mapping between IO-Link and JSON.
+
+      | IO-Link data type | JSON data type |
+      |-------------------|----------------|
+      | BooleanT | Boolean |
+      | StringT | String |
+      | ArrayT | Array |      
+      | IntegerT, UintegerT | Number |
+      | Float32T | Number |
+      | RecordT | Object |
+      | TimeSpanT | String |
+      | TimeT | String |
+      | OctetStringT | Bit sequences that are not interpretable without using information out of the IODD are represented as JSON arrays of decimal numbers. One array item is representing one byte. If the value of the bit sequence is not a multiple of 8, the value is padded with zeros from the left to the next byte border. Byte order is big-endian. See table below. |
+
+      **OctetStringT examples:**
+
+      | Value (bin) | Bit length | Value (hex) | Byte array (dec) |
+      |-------------|------------|-------------|------------------|
+      | 10 0111 | 6 | 0x27 | [39] |
+      | 100 0000 1111 0000 | 15 | 0x40F0 | [64, 240] |
+
+    ## Parameter naming rules
+
+    Parameter and sub-parameter names come from the IODD but are reformatted for JSON/URL compatibility according to these rules:
+      - **Rule 1:** Names are based on the IODD XML Element Name inside variables or process data, resolving the text in primary language.
+      - **Rule 2:** Only alphanumeric characters and underscores are allowed. All other characters are replaced by "**_**".
+      - **Rule 3:** Leading numbers shall be prefixed with "**_**".
+      - **Rule 4:** If there are duplicate IO-Link names, the IO-Link index or subindex has to be accessed by appending the index number or subindex number behind the name according to the scheme: `{name}_{index}` or `{name}_{subindex}`.
+      - **Rule 5:** Naming according to the scheme `{name}_{index}` or `{name}_{subindex}` is always allowed even if names are not duplicated.
+      - **Rule 6:** The naming of ArrayT elements is `element_{subindex}`.
+
+      **Examples:**
+      | IODD text Name | Index/subindex | Parameter name | Unique name (with index) |
+      |----------------|----------------|------|--------------------------|
+      | 0815 variable | 3452 | `_0815_variable` | `_0815_variable_3452` |
+      | Switchpoint (Q1) | 345 | `Switchpoint__Q1_` | `Switchpoint__Q1__345` |
+      | External temperature | 311 | `External_temperature_1` | `External_temperature_311` |
+      | External temperature | 1423 | `External_temperature_1` | `External_temperature_1423` |
+
+    ## Time formats
+
+      Any time values shall be represented either as an absolute time or a relative time in the format as specified in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html). 
+      
+      **NOTE:** Each italic letter in the following format definitions is to be replaced by one digit. The square brackets indicate that an element is optional. 
+
+      The format for absolute time is *`YYYY-MM-DDThh:mm:ss.fZ`* \
+      Time format for relative time is *`P[YY][MM][WW][DD][T[hH][mM][s[.f]S]]`* \
+      Relative time is starting at re-initialization of the system. 
+      
+      **Examples:** \
+      Absolute time:   `2018-05-18T07:31:54.123Z ` \
+      Relative time:   `P3Y6M4DT12H30M17.123S ` 
+
+    ## Error behavior
+
+      While processing HTTP requests errors may occur. There are several errors defined. The body of an HTTP response indicating an error contains the [Error object](#/components/schemas/errorObject). 
+      The following general rules apply for the error handling: \
+      **a)** Errors 101 and 150 (see appendix A.2) can be returned to each request. \
+      **b)** If parts of POST requests are not applicable, the HTTP response has a different HTTP status code than 2xx. The body of this HTTP response shall contain the Error object. \
+      **c)** If multiple errors occur while processing the request only the first detected error shall be responded. \
+      **d)** Errors 305 and 306 (see A.2) can be returned to requests when there are query parameters added to the URL. \
+      **e)** If REST API commands are not available, error 103 (see A.2) shall be responded.
+
   contact:
     email: info@io-link.com
   license:
     name: Legal Information
-    url: "https://io-link.com/en/Global/Impressum.php"
+    url: "https://io-link.com/legal-information"
 
 servers:
   - url: "{scheme}://{host}/{basePath}"
@@ -4213,37 +4280,22 @@ components:
       name: parameterIdent
       in: path
       description: |
-        Parameter name. Comes from the primary language name in the IODD but might be reformatted. \
-        Constraints for strings in keys of JSON key-value-pairs and URLs require the following conversion rules for those names: 
-
-        **Rule 1:** Names are based on the IODD XML Element Name inside variables or process data resolving the text in primary language. \
-        **Rule 2:** Only alphanumeric characters and underscores are allowed. All other characters are replaced by &quot; _ &quot;. \
-        **Rule 3:** Leading numbers shall be prefixed with &quot; _ &quot;.  \
-        **Rule 4:** If there are duplicate IO-Link names, the IO-Link index or subindex has to be accessed by appending the index number or subindex number behind the name according to the following scheme: `{name}_{index}` or `{name}_{subindex}`. \
-        **Rule 5:** Naming according the scheme `{name}_{index}` or `{name}_{subindex}` is always allowed even if names are not duplicated. \
-        **Rule 6:** The naming of ArrayT elements is `element_{subindex}`. \
-
-        **Examples:**
-        | IODD text Name | Index/subindex | Parameter name | Unique name (with index) |
-        |----------------|----------------|------|--------------------------|
-        | 0815 variable | 3452 | `_0815_variable` | `_0815_variable_3452` |
-        | Switchpoint (Q1) | 345 | `Switchpoint__Q1_` | `Switchpoint__Q1__345` |
-        | External temperature | 311 | `External_temperature_1` | `External_temperature_311` |
-        | External temperature | 1423 | `External_temperature_1` | `External_temperature_1423` |
-
+        Parameter identifier. Can be either the parameter index (integer) or the parameter name (string). \
+        Access via parameter names requires IODD support. \
+        Parameter names come from the IODD but are reformatted according to the **Parameter naming rules** described in the general remarks section above.
       required: true
       schema:
         $ref: "./schemas.yaml#/schemas/parameterIdent"
     subParameterIdent:
       name: subParameterIdent
       in: path
-      description: Subparameter access either via subindex or subparametername. Access via subparametername requires IODD support.
+      description: |
+        Sub-Parameter identifier. Can be either the sub parameter index (integer) or the sub parameter name (string). \        
+        Access via subparametername requires IODD support. \
+        Parameter names come from the IODD but are reformatted according to the **Parameter naming rules** described in the general remarks section above.
       required: true
       schema:
-        type: integer
-        minimum: 0
-        maximum: 255
-
+        $ref: "./schemas.yaml#/schemas/subParameterIdent"
   responses:
     HTTP_401:
       description: Authentication information is missing or invalid

--- a/JSON_for_IO-Link_unmerged.yaml
+++ b/JSON_for_IO-Link_unmerged.yaml
@@ -97,7 +97,7 @@ paths:
       summary: >-
         Read the list of available IO-Link-related OpenAPI and AsyncAPI specifications.
       description: >-
-        Read the list of available IO-Link-related OpenAPI and AsyncAPI specifications. The OpenAPI or AsyncAPI specifications should be aligned with vendor-specific requirements such as used security schemas, supported endpoints, or additional information.
+        Read the list of available IO-Link-related OpenAPI and AsyncAPI specifications. The OpenAPI or AsyncAPI specifications should be aligned with vendor-specific requirements such as used security schemas, supported endpoints, or additional information. In addition this endpoint can be used for vendor specific APIs as well.
       responses:
         "200":
           description: Successful operation
@@ -121,9 +121,9 @@ paths:
         - general
       operationId: getApisApiId
       summary: >-
-        Read a specific OpenAPI or AsyncAPI specification.
+        Read a specific OpenAPI or AsyncAPI document.
       description: >-
-        Read a specific OpenAPI or AsyncAPI specification.
+        Read a specific OpenAPI or AsyncAPI document. Either as URL or directly as YAML/JSON content.
       parameters:
         - $ref: "#/components/parameters/apiId"
       responses:
@@ -138,7 +138,7 @@ paths:
                 properties:
                   url:
                     type: string
-                    description: The url referring to the OpenAPI or AsyncAPI specification.
+                    description: The url referring to the OpenAPI or AsyncAPI document.
                     example: https://github.com/iolinkcommunity/JSON_for_IO-Link/blob/2.0.0/JSON_for_IO-Link.yaml
               examples:
                 "url-github":
@@ -173,49 +173,6 @@ paths:
                         name: tbd
                         url: 'http://www.io-link.com'
                     ...
-        "401":
-          $ref: "#/components/responses/HTTP_401"
-        "403":
-          $ref: "#/components/responses/HTTP_403"
-        "500":
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: "./schemas.yaml#/schemas/errorObject_101"
-  /apis/{apiId}/version:
-    get:
-      tags:
-        - general
-      operationId: getApiVersion
-      summary: Read version information of a specific OpenAPI or AsyncAPI specification.
-      description: >-
-        The provided version aligns with the released version by the iolink community on github (e.g. https://github.com/iolinkcommunity/JSON_for_IO-Link/releases).
-        It may be extended by vendor specific parts.
-      parameters:
-        - $ref: "#/components/parameters/apiId"
-      responses:
-        "200":
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - version
-                properties:
-                  version:
-                    type: string
-                  description:
-                    type: string
-              examples:
-                "mandatory content":
-                  value:
-                    version: 2.0.0
-                "optional content":
-                  value:
-                    version: 2.0.0
-                    description: 1.2.3-feature-xyz
         "401":
           $ref: "#/components/responses/HTTP_401"
         "403":
@@ -4133,8 +4090,7 @@ components:
       required: true
       in: path
       schema:
-        type: string
-        pattern: "^[A-Za-z0-9._-]+$"
+        $ref: "./schemas.yaml#/schemas/apiId"
     artifact:
       name: artifact
       description: IO-Link IODD Artifacts

--- a/MQTT_for_IO-Link_unmerged.yaml
+++ b/MQTT_for_IO-Link_unmerged.yaml
@@ -2,16 +2,107 @@ asyncapi: 3.0.0
 info:
   title: MQTT for IO-Link Gateways
   version: 2.0.0
-  description: This is the recommended specification for IO-Link gateway MQTT communication by the IO-Link consortium.
-  termsOfService: "https://www.io-link.com"
+  description: >-
+
+    # Description
+
+    This is an [AsyncAPI specification](https://www.asyncapi.com/docs/reference/specification/v3.0.0) for IO-Link gateways, masters and devices. 
+    You can find out more about IO-Link at [http://www.io-link.com](http://www.io-link.com)    
+
+    # Specifications    
+
+    * **JSON Integration for IO-Link V1.0.0 - Order No: 10.222**
+
+    * **IO-Link Interface and System Specification V1.1.4 - Order No: 10.002**
+
+    * **IO-Link Wireless System Extensions V1.1.3 - Order No: 10.112**
+
+    * **IO-Link Profile BLOBs & FW-Update Version 1.2 - Order No: 10.082**
+
+    * **IO Device Description Specification Version 1.1.4 - Order No: 10.012**
+
+
+    # Disclaimer
+
+    The attention of adopters is directed to the possibility that compliance with or adoption of IO-Link Community specifications may require use of an invention covered by patent rights. The IO-Link Community shall not be responsible for identifying patents for which a license may be required by any IO-Link Community specification, or for conducting legal inquiries into the legal validity or scope of those patents that are brought to its attention. IO-Link Community specifications are prospective and advisory only. Prospective users are responsible for protecting themselves against liability for infringement of patents. 
+
+
+    The information contained in this document is subject to change without notice. The material in this document details an IO-Link Community specification in accordance with the license and notices set forth on this page. This document does not represent a commitment to implement any portion of this specification in any company's products. 
+
+
+    WHILE  THE  INFORMATION  IN  THIS  PUBLICATION   IS  BELIEVED  TO  BE ACCURATE, THE IO-LINK COMMUNITY MAKES NO WARRANTY OF ANY KIND, EXPRESS OR  IMPLIED,  WITH REGARD TO  THIS MATERIAL INCLUDING, BUT  NOT LIMITED  TO  ANY  WARRANTY  OF  TITLE  OR  OWNERSHIP,  IMPLIED  WARRANTY  OF MERCHANTABILITY OR  WARRANTY OF FITNESS FOR  PARTICULAR PURPOSE OR USE.  
+
+
+    In  no  event  shall  the IO-Link Community be liable  for  errors  contained  herein  or  for  indirect, incidental,  special,  consequential,  reliance  or  cover  damages,  including  loss  of profits, revenue, data or use, incurred by any user or any third party.   Compliance  with  this  specification  does  not  absolve  manufacturers  of IO-Link equipment,  from  the  requirements  of  safety  and regulatory agencies (TÜV, BIA, UL, CSA, etc.). 
+
+
+    IO-Link is a registered trademark. It may be used only by the members of the IO-Link Community and non-members who had acquired the corresponding license. For more detailed information on its use, refer to the rules of the IO-Link Community at www.io-link.com.
+
+
+    # General remarks
+
+    ## Data type conversion 
+
+    The following conversion rules shall be applied for the data type mapping between IO-Link and JSON.
+
+      | IO-Link data type | JSON data type |
+      |-------------------|----------------|
+      | BooleanT | Boolean |
+      | StringT | String |
+      | ArrayT | Array |      
+      | IntegerT, UintegerT | Number |
+      | Float32T | Number |
+      | RecordT | Object |
+      | TimeSpanT | String |
+      | TimeT | String |
+      | OctetStringT | Bit sequences that are not interpretable without using information out of the IODD are represented as JSON arrays of decimal numbers. One array item is representing one byte. If the value of the bit sequence is not a multiple of 8, the value is padded with zeros from the left to the next byte border. Byte order is big-endian. See table below. |
+
+      **OctetStringT examples:**
+
+      | Value (bin) | Bit length | Value (hex) | Byte array (dec) |
+      |-------------|------------|-------------|------------------|
+      | 10 0111 | 6 | 0x27 | [39] |
+      | 100 0000 1111 0000 | 15 | 0x40F0 | [64, 240] |
+
+    ## Parameter naming rules
+
+    Parameter and sub-parameter names come from the IODD but are reformatted for JSON/URL compatibility according to these rules:
+      - **Rule 1:** Names are based on the IODD XML Element Name inside variables or process data, resolving the text in primary language.
+      - **Rule 2:** Only alphanumeric characters and underscores are allowed. All other characters are replaced by "**_**".
+      - **Rule 3:** Leading numbers shall be prefixed with "**_**".
+      - **Rule 4:** If there are duplicate IO-Link names, the IO-Link index or subindex has to be accessed by appending the index number or subindex number behind the name according to the scheme: **{name}_{index}** or **{name}_{subindex}**.
+      - **Rule 5:** Naming according to the scheme **{name}_{index}** or **{name}_{subindex}** is always allowed even if names are not duplicated.
+      - **Rule 6:** The naming of ArrayT elements is **element_{subindex}**.
+
+      **Examples:**
+      | IODD text Name | Index/subindex | Parameter name | Unique name (with index) |
+      |----------------|----------------|------|--------------------------|
+      | 0815 variable | 3452 | **_0815_variable** | **_0815_variable_3452** |
+      | Switchpoint (Q1) | 345 | **Switchpoint__Q1_** | **Switchpoint__Q1__345** |
+      | External temperature | 311 | **External_temperature_1** | **External_temperature_311** |
+      | External temperature | 1423 | **External_temperature_1** | **External_temperature_1423** |
+
+    ## Time formats
+
+      Any time values shall be represented either as an absolute time or a relative time in the format as specified in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html). 
+      
+      **NOTE:** Each italic letter in the following format definitions is to be replaced by one digit. The square brackets indicate that an element is optional. 
+
+      The format for absolute time is *YYYY-MM-DDThh:mm:ss.fZ* \
+      Time format for relative time is *P[YY][MM][WW][DD][T[hH][mM][s[.f]S]]* \
+      Relative time is starting at re-initialization of the system. 
+      
+      **Examples:** \
+      Absolute time:   **2018-05-18T07:31:54.123Z** \
+      Relative time:   **P3Y6M4DT12H30M17.123S**
+
   contact:
     name: IO-Link Community
     email: info@io-link.com
     url: "http://www.io-link.com"
   license:
-    name: Apache 2.0
-    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-  tags: [{ "name": "IO-Link IoT" }]
+    name: Legal Information
+    url: "https://io-link.com/legal-information"
 defaultContentType: application/json
 servers:
   iol-master:

--- a/changelog.md
+++ b/changelog.md
@@ -23,8 +23,8 @@ Mandatory endpoint with a note must be implemented if the indicated optional fea
 
 | Endpoint | Description | M/O/C |
 |---|---|---|
-| *[GET] /openapi* | Retrieves the OpenAPI interface description. | M |
-| *[GET] /apiversion* | Retrieves the REST interface version. | M |
+| *[GET] /apis* | Read the list of available IO-Link-related OpenAPI and AsyncAPI specifications with versions. | M |
+| *[GET] /apis/{apiId}* | Read a specific OpenAPI or AsyncAPI document. | M |
 | *[GET] /gateway/diagnosis* | Retrieves the pending events. | M |
 | *[GET] /gateway/monitor* | Retrieves current and voltage values of the gateway. | O |
 | *[POST] /mqtt/topics/{topicId}* | Changes or deactivates a specific MQTT topic. | M - MQTT support |
@@ -39,7 +39,7 @@ Mandatory endpoint with a note must be implemented if the indicated optional fea
 | *[GET] /masters/{masterNumber}/ports/{portNumber}/monitor* | Reads current and voltage or wireless info (depends on the Port type). | O - For Wired Ports / M - For Wireless Ports |
 | *[GET] /masters/{masterNumber}/ports/{portNumber}/power* | Reads the current power mode of the specified port. | C - For Class A with PortPowerOffOn or Class B Ports |
 | *[POST] /masters/{masterNumber}/ports/{portNumber}/power* | Sets the power mode of the specified port. | C - For Class A with PortPowerOffOn or Class B Ports|
-| *[GET] /devices/{deviceAlias}/fwupdate* | Performs Device FW Update procedure. | M - Device FW Update support |
+| *[GET] /devices/{deviceAlias}/fwupdate* | Gives the stage and progress of a running firmware update. | M - Device FW Update support |
 | *[POST] /devices/{deviceAlias}/fwupdate* | Performs Device FW Update procedure. | M - Device FW Update support |
 
 ##### Additions affecting each endpoint

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -283,6 +283,13 @@ schemas:
       - NOT_AVAILABLE # NOT_AVAILABLE
       - PORT_POWER_OFF # PORT_POWER_OFF
       - PAIRING_FAULT # PAIRING_TIMEOUT, PAIRING_WRONG_SLOTTYPE
+  apiId:
+    type: string
+    enum:
+      - IOLINK_REST_V1
+      - IOLINK_REST_V2
+      - IOLINK_MQTT_V1
+    description: An identifier representing a specific OpenAPI or AsyncAPI specification.
   apisGet:
     type: array
     items:
@@ -294,9 +301,7 @@ schemas:
         - description
       properties:
         apiId:
-          type: string
-          pattern: "^[A-Za-z0-9._-]+$"
-          description: An identifier representing a specific OpenAPI or AsyncAPI specification.
+          $ref: "#/schemas/apiId"
         protocol:
           type: string
           enum:
@@ -312,11 +317,11 @@ schemas:
           description: |
             Additional information about the provided specification.
     example:
-      - apiId: JsonForIoLink_REST_v2
+      - apiId: IOLINK_REST_V2
         protocol: REST
         version: 2.0.0
         description: The latest version of the JSON for IO-Link OpenAPI specification.
-      - apiId: JsonForIoLink_MQTT_v1
+      - apiId: IOLINK_MQTT_V1
         protocol: MQTT
         version: 1.0.1
         description: The latest version of the JSON for IO-Link AsyncAPI specification.

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -5,7 +5,7 @@ schemas:
     type: string
     description:
       Unique deviceAlias. Default device name is 'masterNportM' where 'N' means the masterNumber and 'M' means
-      the portNumber. Even if a new device alias has been assigned, the device can always be addressed via the default name.
+      the portNumber. Even if a new device alias has been assigned, the device can always be addressed via the default name. A device name must only contain alphanumeric characters and underscores.
     minLength: 1
     maxLength: 32
     pattern: "^[a-zA-Z0-9_]{1,32}$"
@@ -310,7 +310,7 @@ schemas:
         description:
           type: string
           description: |
-              Additional information about the provided specification.
+            Additional information about the provided specification.
     example:
       - apiId: JsonForIoLink_REST_v2
         protocol: REST
@@ -1232,7 +1232,7 @@ schemas:
             type: string
             minLength: 26
             maxLength: 26
-  portConfigurationGet:         
+  portConfigurationGet:
     anyOf:
       - $ref: "#/schemas/portConfigurationGetWired"
       - $ref: "#/schemas/portConfigurationGetWireless"
@@ -1826,7 +1826,7 @@ schemas:
           - POWER_2
       deviceAlias:
         $ref: "#/schemas/deviceAlias"
-        
+
   portConfigurationPostWireless:
     type: object
     properties:

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -283,6 +283,43 @@ schemas:
       - NOT_AVAILABLE # NOT_AVAILABLE
       - PORT_POWER_OFF # PORT_POWER_OFF
       - PAIRING_FAULT # PAIRING_TIMEOUT, PAIRING_WRONG_SLOTTYPE
+  apisGet:
+    type: array
+    items:
+      type: object
+      required:
+        - apiId
+        - protocol
+        - version
+        - description
+      properties:
+        apiId:
+          type: string
+          pattern: "^[A-Za-z0-9._-]+$"
+          description: An identifier representing a specific OpenAPI or AsyncAPI specification.
+        protocol:
+          type: string
+          enum:
+            - REST
+            - MQTT
+          description: The specification type.
+        version:
+          type: string
+          description: |
+            The version of the OpenAPI or AsyncAPI specification.
+        description:
+          type: string
+          description: |
+              Additional information about the provided specification.
+    example:
+      - apiId: JsonForIoLink_REST_v2
+        protocol: REST
+        version: 2.0.0
+        description: The latest version of the JSON for IO-Link OpenAPI specification.
+      - apiId: JsonForIoLink_MQTT_v1
+        protocol: MQTT
+        version: 1.0.1
+        description: The latest version of the JSON for IO-Link AsyncAPI specification.
   masterIdentificationPost:
     type: object
     description: At least one of the properties has to be used, if the request is issued.

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -31,33 +31,19 @@ schemas:
     # minLength: 1
     # maxLength: 64
   parameterIdentMqtt: # path parameter shall not contain a type according to async api spec
-    description: Identifier of the parameter. It can be the parameterName or the index of the parameter.
+    description: Identifier of the parameter. It can be the parameterName or the index of the parameter. For details see Parameter naming rules in General remarks. \
   subParameterIdentMqtt: # path parameter shall not contain a type according to async api spec
-    description: Identifier of the sub-parameter. It can be the sub-parameterName or the sub-index of the parameter.
+    description: Identifier of the sub-parameter. It can be the sub-parameterName or the sub-index of the parameter. For details see Parameter naming rules in General remarks. \
   parameterName:
     type: string
     description: |
-      Parameter name. Comes from the IODD but might be reformatted according to the JSON mapping specification. \
-      Constraints for strings in keys of JSON key-value-pairs (see [9]) and URLs require the following conversion rules for those names: \
-      Rule 1: Names are based on the IODD XML Element Name inside variables or process data 159 resolving the text in primary language. \
-      Rule 2: Only alphanumeric characters and underscores are allowed. All other characters are replaced by "_". The following regex (/[^\w\n]/g) can be used.\
-      Rule 3: Leading numbers shall be prefixed with “_“.  \
-      Rule 4: If there are duplicate IO-Link names, the IO-Link index or subindex has to be accessed by appending the index number or subindex number behind the name according to the following scheme: {name}_{index} or {name}_{subindex}. \
-      Rule 5: Naming according the scheme {name}_{index} or {name}_{subindex} is always allowed even if names are not duplicated. \
-      Rule 6: The naming of ArrayT elements is “element_{subindex}”. \
+      Parameter name. For details see Parameter naming rules in General remarks. \
     minLength: 1
     maxLength: 64
   subParameterName:
     type: string
     description: |
-      Sub-parameter name. Comes from the IODD but might be reformatted according to the JSON mapping specification. \
-      Constraints for strings in keys of JSON key-value-pairs (see [9]) and URLs require the following conversion rules for those names: \
-      Rule 1: Names are based on the IODD XML Element Name inside variables or process data 159 resolving the text in primary language. \
-      Rule 2: Only alphanumeric characters and underscores are allowed. All other characters are replaced by "_". The following regex (/[^\w\n]/g) can be used. \
-      Rule 3: Leading numbers shall be prefixed with “_“. \
-      Rule 4: If there are duplicate IO-Link names, the IO-Link index or subindex has to be accessed by appending the index number or subindex number behind the name according to the following scheme: {name}_{index} or {name}_{subindex}. \
-      Rule 5: Naming according the scheme {name}_{index} or {name}_{subindex} is always allowed even if names are not duplicated. \
-      Rule 6: The naming of ArrayT elements is “element_{subindex}”. \
+      Sub-parameter name. For details see Parameter naming rules in General remarks. \
     minLength: 1
     maxLength: 64
   cycleTime:
@@ -3411,6 +3397,10 @@ schemas:
     oneOf:
       - $ref: "#/schemas/parameterName"
       - $ref: "#/schemas/index"
+  subParameterIdent:
+    oneOf:
+      - $ref: "#/schemas/subParameterName"
+      - $ref: "#/schemas/subIndex"
   rawSmi:
     type: object
     properties:


### PR DESCRIPTION
With the release of version 2 of JSON Integration for IO-Link, several OpenAPI specifications and an additional AsyncAPI are now available. Users should be granted access to both API types, possibly in different versions.