### PR TITLE
FW Update for Constrained Devices

### DIFF
--- a/JSON_for_IO-Link_unmerged.yaml
+++ b/JSON_for_IO-Link_unmerged.yaml
@@ -1661,6 +1661,9 @@ paths:
                     maxPowerSupply: # max power supply per port
                       value: 0.3
                       unit: A
+                    maxStorageCapacity:
+                      value: 4096
+                      unit: kB
                 IO-Link_Wireless:
                   value:
                     numberOfPorts: 40
@@ -4040,8 +4043,14 @@ paths:
       operationId: PostDevicesDeviceAliasFirmwareUpdate
       tags:
         - devices
-      summary: Perform a firmware update for a specific Device with an iolfw-file according to specification IOL-Profile_Firmware-Update_V11_10082_Sep19. Device FW Update support is required.
-      description: Perform a firmware update for a specific Device with an iolfw-file according to specification IOL-Profile_Firmware-Update_V11_10082_Sep19. Device FW Update support is required.
+      summary: >
+        Perform a firmware update for a specific Device using either a complete iolfw file or an extracted binary firmware file
+        with additional mandatory meta information according to specification IOL-Profile_Firmware-Update_V11_10082_Sep19.
+        Device FW Update support is required.
+      description: >
+        Perform a firmware update for a specific Device using either a complete iolfw file or an extracted binary firmware file
+        with additional mandatory meta information according to specification IOL-Profile_Firmware-Update_V11_10082_Sep19.
+        Device FW Update support is required.
       parameters:
         - $ref: "#/components/parameters/deviceAlias"
       responses:
@@ -4077,7 +4086,10 @@ paths:
                   - $ref: "./schemas.yaml#/schemas/errorObject_102"
       requestBody:
         required: true
-        description: The firmware update file in iolfw format. The file must be provided as a multipart/form-data request including the `filename` as header parameter (see RFC7578).
+        description: >
+          The firmware update file, either as a complete iolfw file or as an extracted binary firmware
+          file with additional mandatory meta information. The file must be provided as a multipart/form-data
+          request including the `filename` as header parameter (see RFC7578).
         content:
           multipart/form-data:
             schema:

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -314,12 +314,29 @@ schemas:
     required:
       - numberOfPorts
       - maxPowerSupply
+      - maxStorageCapacity
     type: object
     properties:
       numberOfPorts:
         $ref: "#/schemas/portNumber"
       maxPowerSupply:
         $ref: "#/schemas/currentObject"
+      maxStorageCapacity:
+        required:
+          - value
+          - unit
+        description: >-
+          Maximum capacity available on the host device for storing extracted iolfw file content.
+        type: object
+        properties:
+          value:
+            type: integer
+            minimum: 0
+          unit:
+            type: string
+            enum:
+              - kB
+            default: kB
   masterCapabilitiesGetWireless:
     required:
       - numberOfPorts
@@ -3320,16 +3337,49 @@ schemas:
         maximum: 100
   deviceFirmwareUpdatePost:
     type: object
-    properties:
-      password:
-        type: string
-        description: password for updating the device if required
-      iolfwfile:
-        type: string
-        format: binary
-        description: IOLFW File for the device
-    required:
-      - iolfwfile
+    oneOf:
+      - type: object
+        properties:
+          password:
+            type: string
+            description: password for updating the device if required
+          iolfwfile:
+            type: string
+            format: binary
+            description: IOLFW File for the device
+        required:
+          - iolfwfile
+      - type: object
+        properties:
+          password:
+            type: string
+            description: password for updating the device if required
+          hardwareIdKey:
+            type: string
+            description: >
+              The identifier that must match the hardware id key within the device to ensure
+              compatibility, linking the firmware update data to the specific hardware variants
+              for which it can be used, and is checked by the update software before allowing a
+              firmware update to proceed.
+          vendorId:
+            $ref: "#/schemas/vendorId"
+          activationRetryCount:
+            type: integer
+            description: >
+              Maximum number of automatic retries (default: 3) the host tool performs when
+              polling the device for successful activation of new firmware after an update.
+            default: 3
+            minimum: 1
+          binfwfile:
+            type: string
+            format: binary
+            description: >
+              The binary firmware file contained in the iolfw file, representing the actual
+              firmware image to be transferred to the device during a firmware update.
+        required:
+          - hardwareIdKey
+          - vendorId          
+          - binfwfile
   devicesGet:
     type: array
     items:


### PR DESCRIPTION
_Support firmware updates on constrained IO‑Link devices via binary‑only uploads with host storage query_

**Summary**

This change extends the existing IO‑Link firmware update capability to support devices that cannot buffer a complete IOLFW package in on‑device flash. Instead of requiring the full .iolfw archive, the client can upload only the raw binary firmware image plus additional meta information, and query the host’s maximum temporary storage capacity before initiating the transfer. The approach reduces upload time (especially for packages that include non‑essential assets such as manuals or changelogs) while preserving compatibility with the IO‑Link Firmware Update Profile.