### PR TITLE
Remove empty MQTT events and improvement of examples

### DIFF
--- a/JSON_for_IO-Link_unmerged.yaml
+++ b/JSON_for_IO-Link_unmerged.yaml
@@ -996,7 +996,7 @@ paths:
               example:
                 - topicId: 1
                   activate: true
-                  topicName: Sensor34/processData
+                  topicName: master001-6a624757-30a2-481e-a889-edafeaa025a6/master1port1/processdata
                   qos: 1_AT_LEAST_ONCE
                   deviceAlias: DT35
                   processData:
@@ -1007,13 +1007,12 @@ paths:
                       unit: ms
                 - topicId: 2
                   activate: true
-                  topicName: Sensor34/event
+                  topicName: master001-6a624757-30a2-481e-a889-edafeaa025a6/TAD08/events
                   qos: 1_AT_LEAST_ONCE
                   deviceAlias: TAD081
-                  event: {}
                 - topicId: 3
                   activate: false
-                  topicName: PD
+                  topicName: master001-6a624757-30a2-481e-a889-edafeaa025a6/processdata
                   qos: 0_ONLY_ONCE
                   deviceAlias: BNI_IOL
                   processData:
@@ -1022,7 +1021,7 @@ paths:
                     onChange: true
                 - topicId: 4
                   activate: false
-                  topicName: DT35_CycleTime
+                  topicName: master001-6a624757-30a2-481e-a889-edafeaa025a6/dt35_cycle_time
                   qos: 0_ONLY_ONCE
                   deviceAlias: DT35
                   parameter:
@@ -1032,7 +1031,7 @@ paths:
                     onChange: true
                 - topicId: 5
                   activate: true
-                  topicName: deviceTemperature
+                  topicName: master001-6a624757-30a2-481e-a889-edafeaa025a6/deviceTemperature
                   qos: 0_ONLY_ONCE
                   deviceAlias: master1port2
                   parameter:
@@ -1041,6 +1040,11 @@ paths:
                     interval:
                       value: 10
                       unit: ms
+                - topicId: 6
+                  activate: true
+                  topicName: master001-6a624757-30a2-481e-a889-edafeaa025a6/TAD08/sensor34/event
+                  qos: 1_AT_LEAST_ONCE
+                  deviceAlias: TAD081
         "401":
           $ref: "#/components/responses/HTTP_401"
         "403":
@@ -1081,19 +1085,13 @@ paths:
                 value:
                   activate: true
                   qos: 1_AT_LEAST_ONCE
-                  deviceAlias: DT35
+                  deviceAlias: master1port1
                   processData:
                     direction: getData
                     format: iodd
                     interval:
                       value: 10
                       unit: ms
-              Event:
-                value:
-                  activate: true
-                  qos: 1_AT_LEAST_ONCE
-                  deviceAlias: TAD081
-                  event: {}
               Parameter (Index):
                 value:
                   activate: false
@@ -1108,7 +1106,7 @@ paths:
               Parameter (ParameterName):
                 value:
                   activate: true
-                  topicName: deviceTemperature
+                  topicName: device_temperature
                   qos: 0_ONLY_ONCE
                   deviceAlias: AHM36A
                   parameter:
@@ -1188,7 +1186,7 @@ paths:
                   value:
                     topicId: 1
                     activate: true
-                    topicName: PD input
+                    topicName: master001-6a624757-30a2-481e-a889-edafeaa025a6/pd_input
                     qos: 1_AT_LEAST_ONCE
                     deviceAlias: DT35
                     processData:
@@ -1197,19 +1195,11 @@ paths:
                       interval:
                         value: 10
                         unit: ms
-                Event:
-                  value:
-                    topicId: 2
-                    activate: true
-                    topicName: Event
-                    qos: 1_AT_LEAST_ONCE
-                    deviceAlias: TAD081
-                    event: {}
                 Parameter (Index):
                   value:
                     topicId: 3
                     activate: true
-                    topicName: devvice/indexXY
+                    topicName: master001-6a624757-30a2-481e-a889-edafeaa025a6/device/index_xy
                     qos: 0_ONLY_ONCE
                     deviceAlias: master1port1
                     parameter:
@@ -1222,7 +1212,7 @@ paths:
                   value:
                     topicId: 5
                     activate: true
-                    topicName: deviceTemperature
+                    topicName: master001-6a624757-30a2-481e-a889-edafeaa025a6/device_temperature
                     qos: 0_ONLY_ONCE
                     deviceAlias: AHM36A
                     parameter:
@@ -1281,7 +1271,7 @@ paths:
                 value:
                   topicId: 1
                   activate: true
-                  topicName: PD input
+                  topicName: pd_input
                   qos: 1_AT_LEAST_ONCE
                   deviceAlias: DT35
                   processData:
@@ -1290,18 +1280,10 @@ paths:
                     interval:
                       value: 10
                       unit: ms
-              Event:
-                value:
-                  topicId: 2
-                  activate: true
-                  topicName: Event
-                  qos: 1_AT_LEAST_ONCE
-                  deviceAlias: TAD081
-                  event: {}
               Parameter (Index):
                 value:
                   topicId: 3
-                  topicName: devvice/indexXY
+                  topicName: device_index_xy
                   qos: 0_ONLY_ONCE
                   deviceAlias: master1port1
                   parameter:
@@ -1314,7 +1296,7 @@ paths:
                 value:
                   topicId: 5
                   activate: true
-                  topicName: deviceTemperature
+                  topicName: device_temperature
                   qos: 0_ONLY_ONCE
                   deviceAlias: AHM36A
                   parameter:

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -851,7 +851,7 @@ schemas:
       - $ref: "#/schemas/mqttConfigurationTopic"
     example:
       topicId: 1
-      topicName: PD input
+      topicName: pd_input
       qos: 1_AT_LEAST_ONCE
       deviceAlias: DT35
       processData:
@@ -871,7 +871,7 @@ schemas:
     example:
       topicId: 1
       activate: true
-      topicName: PD input
+      topicName: pd_input
       qos: 1_AT_LEAST_ONCE
       deviceAlias: DT35
       processData:
@@ -3797,22 +3797,22 @@ schemas:
     type: string
     description: >-
       MQTT topic name is bound to a device and individual topics can be created. The configured originatorId will be automatically added when data is published. <br>
-      In case no topic name is provided the following structure will be used: &lt;originatorId&gt;/&lt;deviceAlias&gt;/&lt;type&gt;[/&lt;parameter&gt;] <br>
+      In case no topic name is provided the following structure will be used: &lt;originatorId&gt;/&lt;devices/&lt;deviceAlias&gt;/&lt;type&gt;[/&lt;parameter&gt;] <br>
       Where: <br>
       - &lt;originatorId&gt; is the unique identifier of the gateway which will be added automatically <br>
       - &lt;deviceAlias&gt; is the device alias <br>
-      - &lt;type&gt; can be: processData, events, or parameter <br>
+      - &lt;type&gt; can be: processdata, events, or parameter <br>
       - &lt;parameter&gt; is optional and used for parameter topics (index or parameterName) <br>
       <br>
       Examples: <br>
-      - master001-6a624757-30a2-481e-a889-edafeaa025a6/master1port1/processData <br>
-      - master001-6a624757-30a2-481e-a889-edafeaa025a6/master1port1/events <br>
-      - master001-6a624757-30a2-481e-a889-edafeaa025a6/master1port1/parameter/123 <br>
-      - master001-6a624757-30a2-481e-a889-edafeaa025a6/master1port1/parameter/temperature <br>
+      - master001-6a624757-30a2-481e-a889-edafeaa025a6/devices/master1port1/processdata <br>
+      - master001-6a624757-30a2-481e-a889-edafeaa025a6/devices/master1port1/events <br>
+      - master001-6a624757-30a2-481e-a889-edafeaa025a6/devices/master1port1/parameter/123 <br>
+      - master001-6a624757-30a2-481e-a889-edafeaa025a6/devices/master1port1/parameter/temperature <br>
       <br>
     minLength: 1
     maxLength: 256
-    example: "master001-6a624757-30a2-481e-a889-edafeaa025a6/master1port1/processData"
+    example: "master001-6a624757-30a2-481e-a889-edafeaa025a6/devices/master1port1/processdata"
   mqttTopicId:
     type: integer
     description: The topic id as a reference to a topic name. The management of the topic ids is done by the gateway.

--- a/schemas.yaml
+++ b/schemas.yaml
@@ -833,8 +833,6 @@ schemas:
       - oneOf:
           - type: object
             properties:
-              event:
-                $ref: "#/schemas/event"
               processData:
                 $ref: "#/schemas/processData"
               parameter:


### PR DESCRIPTION
Adjustment of topic examples (upper case in topic names are not recommended, added originatorId)
Remove empty event objects from schema. 
MQTT events are defined by the async api document.

Fixes #199 