### PR TITLE
Add possibility to get only pending events from /events 

### DIFF
--- a/JSON_for_IO-Link_unmerged.yaml
+++ b/JSON_for_IO-Link_unmerged.yaml
@@ -507,7 +507,7 @@ paths:
       summary: Read the EventLog containing all events from Gateway, Masters, Ports and Devices.
       description:
         Each Gateway shall have an Event Log object containing the events of the devices, ports and
-        the masters. The content of the Event Log can be read by getting the object "Gateway Event Log"
+        the masters.
       parameters:
         - $ref: "#/components/parameters/eventOrigin"
         - $ref: "#/components/parameters/eventMasterNumber"
@@ -515,6 +515,7 @@ paths:
         - $ref: "#/components/parameters/eventdeviceAlias"
         - $ref: "#/components/parameters/eventTop"
         - $ref: "#/components/parameters/eventBottom"
+        - $ref: "#/components/parameters/onlyPendingEvents"
       responses:
         "200":
           description: Successful operation
@@ -680,136 +681,6 @@ paths:
               schema:
                 $ref: "./schemas.yaml#/schemas/errorObject_101"
 
-  "/gateway/diagnosis":
-    get:
-      operationId: GetGatewayDiagnosis
-      tags:
-        - gateway
-      summary: Get the currently pending events.
-      description: >-
-        Each event with a *mode* of "APPEARS" is considered as an pending event until the occurence of a corresponding with *mode* of "DISAPPEARS".
-        Pending events must be provided regardless of the Event Log content.
-          
-        Hint: *mode* is optional property under *message*. An event cannot qualify as a pending event if this property is not specified.
-      parameters:
-        - $ref: "#/components/parameters/eventOrigin"
-        - $ref: "#/components/parameters/eventMasterNumber"
-        - $ref: "#/components/parameters/eventPortNumber"
-        - $ref: "#/components/parameters/eventdeviceAlias"
-      responses:
-        "200":
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  anyOf:
-                    - $ref: "./schemas.yaml#/schemas/gatewayEventGet"
-                    - $ref: "./schemas.yaml#/schemas/masterEventGet"
-                    - $ref: "./schemas.yaml#/schemas/portEventGet"
-                    - $ref: "./schemas.yaml#/schemas/deviceEventGet"
-              examples:
-                origin=ALL:
-                  value:
-                    - time: "2018-05-18T07:32:42.023Z"
-                      severity: ERROR
-                      origin:
-                        masterNumber: 1
-                        portNumber: 1
-                      message:
-                        code: 6163
-                        mode: APPEARS
-                        text: Overcurrent at C/Q (if digital output) - check load
-                    - time: "2018-05-18T07:31:54.123Z"
-                      severity: WARNING
-                      origin:
-                        masterNumber: 1
-                        portNumber: 1
-                        deviceAlias: Temp_sensor_1
-                      message:
-                        code: 16912
-                        mode: APPEARS
-                        text: Device temperature over-run – Clear source of heat
-                    - time: "2018-05-18T08:31:54.123Z"
-                      severity: ERROR
-                      origin:
-                        masterNumber: 1
-                        portNumber: 3
-                        deviceAlias: Distance_Laser_3
-                      message:
-                        code: 20480
-                        mode: APPEARS
-                        text: Device hardware fault – Device exchange
-                    - time: "2018-05-18T07:35:54.123Z"
-                      severity: NOTICE
-                      origin:
-                        masterNumber: 1
-                        portNumber: 2
-                      message:
-                        code: 65313
-                        mode: SINGLESHOT
-                        text: New slave
-                origin=PORTS:
-                  value:
-                    - time: "2018-05-18T07:32:42.023Z"
-                      severity: ERROR
-                      origin:
-                        masterNumber: 1
-                        port: 1
-                      message:
-                        code: 6163
-                        mode: APPEARS
-                        text: Overcurrent at C/Q (if digital output) - check load
-                    - time: "2018-05-18T07:35:54.123Z"
-                      severity: NOTICE
-                      origin:
-                        masterNumber: 1
-                        portNumber: 2
-                      message:
-                        code: 65313
-                        mode: SINGLESHOT
-                        text: New slave
-                origin=DEVICES:
-                  value:
-                    - time: "2018-05-18T07:31:54.123Z"
-                      severity: WARNING
-                      origin:
-                        masterNumber: 1
-                        portNumber: 1
-                        deviceAlias: Temp_sensor_1
-                      message:
-                        code: 16912
-                        mode: APPEARS
-                        text: Device temperature over-run – Clear source of heat
-                    - time: "2018-05-18T08:31:54.123Z"
-                      severity: ERROR
-                      origin:
-                        masterNumber: 1
-                        portNumber: 3
-                        deviceAlias: Distance_Laser_3
-                      message:
-                        code: 20480
-                        mode: APPEARS
-                        text: Device hardware fault – Device exchange
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: "./schemas.yaml#/schemas/errorObject_305"
-                  - $ref: "./schemas.yaml#/schemas/errorObject_306"
-        "401":
-          $ref: "#/components/responses/HTTP_401"
-        "403":
-          $ref: "#/components/responses/HTTP_403"
-        "500":
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: "./schemas.yaml#/schemas/errorObject_101"
   "/gateway/monitor":
     get:
       operationId: GetGatewayMonitor
@@ -4270,6 +4141,16 @@ components:
         exclusive to top.
       schema:
         $ref: "./schemas.yaml#/schemas/eventBottom"
+    onlyPendingEvents:
+      name: onlyPendingEvents
+      in: query
+      description: |
+        If true, only pending events will be returned. Each event with a *mode* of "APPEARS" is considered as an pending event until the occurence of a corresponding with *mode* of "DISAPPEARS".
+        Pending events must be provided regardless of the Event Log content.
+          
+        Hint: *mode* is optional property under *message*. An event cannot qualify as a pending event if this property is not specified.
+      schema:
+        type: boolean
     format:
       name: format
       in: query


### PR DESCRIPTION
In order to unify the event access the /diagnosis endpoint has been removed and a query parameter for /events has been introduced.

See #211 